### PR TITLE
ISSUE-2: Upgrade langgraph to v0.2

### DIFF
--- a/agent/llama_guard.py
+++ b/agent/llama_guard.py
@@ -34,11 +34,13 @@ unsafe_content_categories = {
     "S14": "Code Interpreter Abuse."
 }
 
+formatted_unsafe_content_categories = "\n".join([f"{k}: {v}" for k, v in unsafe_content_categories.items()])
+
 llama_guard_instructions = f"""
 [INST] Task: Check if there is unsafe content in '{{role}}' messages in conversations according our safety policy with the below categories.
 
 <BEGIN UNSAFE CONTENT CATEGORIES>
-{"\n".join([f"{k}: {v}" for k, v in unsafe_content_categories.items()])}
+{formatted_unsafe_content_categories}
 <END UNSAFE CONTENT CATEGORIES>
 
 <BEGIN CONVERSATION>

--- a/agent/research_assistant.py
+++ b/agent/research_assistant.py
@@ -5,7 +5,7 @@ from langchain_groq import ChatGroq
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage, RemoveMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda
-from langgraph.checkpoint import MemorySaver
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph, MessagesState
 from langgraph.managed import IsLastStep
 from langgraph.prebuilt import ToolNode

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ langchain-core~=0.2.26
 langchain-community~=0.2.11
 langchain-openai~=0.1.20
 langchain-groq~=0.1.9
-langgraph==0.1.19
+langgraph~=0.2.3
+langgraph-checkpoint-sqlite~=1.0.0
 langsmith~=0.1.96
 numexpr~=2.10.1
 pydantic~=1.10.17

--- a/service/service.py
+++ b/service/service.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.runnables import RunnableConfig
-from langgraph.checkpoint.aiosqlite import AsyncSqliteSaver
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.graph.graph import CompiledGraph
 from langsmith import Client as LangsmithClient
 

--- a/service/test_service.py
+++ b/service/test_service.py
@@ -7,18 +7,19 @@ from schema import ChatMessage
 
 client = TestClient(app)
 
-@patch("service.service.construct_agent")
+@patch("service.service.CompiledGraph")
 def test_invoke(mock_construct_agent):
     agent = mock_construct_agent.return_value
     QUESTION = "What is the weather in Tokyo?"
     ANSWER = "The weather in Tokyo is 70 degrees."
     agent_response = {"messages": [AIMessage(content=ANSWER)]}
     agent.ainvoke = AsyncMock(return_value=agent_response)
-    
-    with client as c:
-        response = c.post("/invoke", json={"message": QUESTION})
-        assert response.status_code == 200
-    
+
+    app.state.agent = agent
+
+    response = client.post("/invoke", json={"message": QUESTION})
+    assert response.status_code == 200
+
     agent.ainvoke.assert_awaited_once()
     input_message = agent.ainvoke.await_args.kwargs["input"]["messages"][0]
     assert input_message.content == QUESTION


### PR DESCRIPTION

- Upgraded the langgraph dependency to version 0.2.
  - langgraph SQLite checkpoint now has its own package: langgraph-checkpoint-sqlite.
  - Fixed any breaking changes that arose from the update.

- Fixed `test_invoke` and ensured all tests pass