### PR TITLE
Also allow feedback of 1 star

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -264,7 +264,7 @@ async def handle_feedback():
     feedback = st.feedback("stars", key=latest_run_id)
 
     # If the feedback value or run ID has changed, send a new feedback record
-    if feedback and (latest_run_id, feedback) != st.session_state.last_feedback:
+    if feedback is not None and (latest_run_id, feedback) != st.session_state.last_feedback:
         # Normalize the feedback value (an index) to a score between 0 and 1
         normalized_score = (feedback + 1) / 5.0
 


### PR DESCRIPTION
Currently, clicking 1 star for feedback results in `st.feedback()` returning `0` (see https://docs.streamlit.io/develop/api-reference/widgets/st.feedback), and this `if` is not entered:
https://github.com/JoshuaC215/agent-service-toolkit/blob/fbf072de05a8a5ea911fc484a0e8c0516dab8ea4/src/streamlit_app.py#L264-L269