### PR TITLE
Add the "I" series rules in ruff (isort operation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,8 @@ dev = [
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.lint]
+extend-select = ["I"]
+
 [tool.pytest_env]
 OPENAI_API_KEY = "sk-fake-openai-key"

--- a/src/agent/llama_guard.py
+++ b/src/agent/llama_guard.py
@@ -1,9 +1,10 @@
 import os
-from langchain_core.messages import AnyMessage, HumanMessage, AIMessage
+from enum import Enum
+from typing import List
+
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
 from langchain_core.prompts import PromptTemplate
 from langchain_groq import ChatGroq
-from typing import List
-from enum import Enum
 from pydantic import BaseModel, Field
 
 

--- a/src/agent/research_assistant.py
+++ b/src/agent/research_assistant.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 import os
 from langchain_openai import ChatOpenAI
@@ -8,13 +9,16 @@ from langchain_community.tools import DuckDuckGoSearchResults, OpenWeatherMapQue
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_groq import ChatGroq
+from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import END, StateGraph, MessagesState
+from langgraph.graph import END, MessagesState, StateGraph
 from langgraph.managed import IsLastStep
 from langgraph.prebuilt import ToolNode
 
-from agent.tools import calculator
 from agent.llama_guard import LlamaGuard, LlamaGuardOutput, SafetyAssessment
+from agent.tools import calculator
 
 
 class AgentState(MessagesState):
@@ -162,6 +166,7 @@ research_assistant = agent.compile(
 if __name__ == "__main__":
     import asyncio
     from uuid import uuid4
+
     from dotenv import load_dotenv
 
     load_dotenv()

--- a/src/agent/research_assistant.py
+++ b/src/agent/research_assistant.py
@@ -1,9 +1,6 @@
 import os
 from datetime import datetime
-import os
-from langchain_openai import ChatOpenAI
-from langchain_groq import ChatGroq
-from langchain_google_genai import ChatGoogleGenerativeAI
+
 from langchain_anthropic import ChatAnthropic
 from langchain_community.tools import DuckDuckGoSearchResults, OpenWeatherMapQueryRun
 from langchain_core.language_models.chat_models import BaseChatModel

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,7 +1,8 @@
 import math
-import numexpr
 import re
-from langchain_core.tools import tool, BaseTool
+
+import numexpr
+from langchain_core.tools import BaseTool, tool
 
 
 def calculator_func(expression: str) -> str:

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1,8 +1,10 @@
 import json
 import os
+from typing import Any, AsyncGenerator, Dict, Generator
+
 import httpx
-from typing import AsyncGenerator, Dict, Any, Generator
-from schema import ChatMessage, UserInput, StreamInput, Feedback
+
+from schema import ChatMessage, Feedback, StreamInput, UserInput
 
 
 class AgentClient:

--- a/src/run_client.py
+++ b/src/run_client.py
@@ -1,8 +1,8 @@
-from client import AgentClient
-from schema import ChatMessage
-
 #### ASYNC ####
 import asyncio
+
+from client import AgentClient
+from schema import ChatMessage
 
 
 async def amain():

--- a/src/run_service.py
+++ b/src/run_service.py
@@ -1,5 +1,5 @@
-from dotenv import load_dotenv
 import uvicorn
+from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,9 +1,9 @@
 from schema.schema import (
-    UserInput,
     AgentResponse,
     ChatMessage,
-    StreamInput,
     Feedback,
+    StreamInput,
+    UserInput,
     convert_message_content_to_string,
 )
 

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any, List, Literal, Union
+from typing import Any, Dict, List, Literal, Union
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -1,10 +1,10 @@
 from typing import Dict, Any, List, Literal, Union
 from langchain_core.messages import (
+    AIMessage,
     BaseMessage,
     HumanMessage,
-    AIMessage,
-    ToolMessage,
     ToolCall,
+    ToolMessage,
     message_to_dict,
     messages_from_dict,
 )

--- a/src/schema/test_schema.py
+++ b/src/schema/test_schema.py
@@ -1,4 +1,5 @@
-from langchain_core.messages import HumanMessage, AIMessage, ToolMessage, SystemMessage, ToolCall
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
+
 from schema import ChatMessage
 
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -2,7 +2,7 @@ import json
 import os
 import warnings
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Dict, Tuple
+from typing import Any, AsyncGenerator, Dict, List, Tuple, Union
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException, Request, Response
@@ -14,7 +14,7 @@ from langgraph.graph.graph import CompiledGraph
 from langsmith import Client as LangsmithClient
 
 from agent import research_assistant
-from schema import ChatMessage, Feedback, UserInput, StreamInput, convert_message_content_to_string
+from schema import ChatMessage, Feedback, StreamInput, UserInput, convert_message_content_to_string
 
 warnings.filterwarnings("ignore", category=LangChainBetaWarning)
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -1,9 +1,10 @@
-from contextlib import asynccontextmanager
 import json
 import os
 import warnings
-from typing import AsyncGenerator, Dict, Any, Tuple, List, Union
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator, Dict, Tuple
 from uuid import uuid4
+
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from langchain_core._api import LangChainBetaWarning

--- a/src/service/test_service.py
+++ b/src/service/test_service.py
@@ -1,9 +1,10 @@
-from langchain_core.messages import AIMessage
-from fastapi.testclient import TestClient
-from unittest.mock import patch, AsyncMock
+from unittest.mock import AsyncMock, patch
 
-from service import app
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+
 from schema import ChatMessage
+from service import app
 
 client = TestClient(app)
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -4,9 +4,9 @@ from typing import AsyncGenerator, List
 
 import streamlit as st
 from streamlit.runtime.scriptrunner import get_script_run_ctx
+
 from client import AgentClient
 from schema import ChatMessage
-
 
 # A Streamlit app for interacting with the langgraph agent via a simple chat interface.
 # The app has three main functions which are all run async:


### PR DESCRIPTION
Due to the mixing of built-in imports and third-party imports, it is difficult to distinguish the source of the packages.
Used the "I" series rules in ruff (an operation similar to isort) to solve this issue.

All the code in this PR was modified using `ruff check --fix`, and future checks can be done through pre-commit.