### PR TITLE
feat: add HTTPBearer check

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -1,13 +1,14 @@
 import json
 import os
 import warnings
-from collections.abc import AsyncGenerator, Callable
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Annotated, Any
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from langchain_core._api import LangChainBetaWarning
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
@@ -27,6 +28,19 @@ from schema import (
 warnings.filterwarnings("ignore", category=LangChainBetaWarning)
 
 
+def verify_bearer(
+    http_auth: Annotated[
+        HTTPAuthorizationCredentials,
+        Depends(HTTPBearer(description="Please provide AUTH_SECRET api key.")),
+    ],
+) -> None:
+    if http_auth.credentials != os.getenv("AUTH_SECRET"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+
+bearer_depend = [Depends(verify_bearer)] if os.getenv("AUTH_SECRET") else None
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Construct agent with Sqlite checkpointer
@@ -38,17 +52,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(lifespan=lifespan)
-
-
-@app.middleware("http")
-async def check_auth_header(request: Request, call_next: Callable) -> Response:
-    if auth_secret := os.getenv("AUTH_SECRET"):
-        auth_header = request.headers.get("Authorization")
-        if not auth_header or not auth_header.startswith("Bearer "):
-            return Response(status_code=401, content="Missing or invalid token")
-        if auth_header[7:] != auth_secret:
-            return Response(status_code=401, content="Invalid token")
-    return await call_next(request)
+router = APIRouter(dependencies=bearer_depend)
 
 
 def _parse_input(user_input: UserInput) -> tuple[dict[str, Any], str]:
@@ -76,7 +80,7 @@ def _remove_tool_calls(content: str | list[str | dict]) -> str | list[str | dict
     ]
 
 
-@app.post("/invoke")
+@router.post("/invoke")
 async def invoke(user_input: UserInput) -> ChatMessage:
     """
     Invoke the agent with user input to retrieve a final response.
@@ -161,7 +165,7 @@ def _sse_response_example() -> dict[int, Any]:
     }
 
 
-@app.post("/stream", response_class=StreamingResponse, responses=_sse_response_example())
+@router.post("/stream", response_class=StreamingResponse, responses=_sse_response_example())
 async def stream_agent(user_input: StreamInput) -> StreamingResponse:
     """
     Stream the agent's response to a user input, including intermediate messages and tokens.
@@ -172,7 +176,7 @@ async def stream_agent(user_input: StreamInput) -> StreamingResponse:
     return StreamingResponse(message_generator(user_input), media_type="text/event-stream")
 
 
-@app.post("/feedback")
+@router.post("/feedback")
 async def feedback(feedback: Feedback) -> FeedbackResponse:
     """
     Record feedback for a run to LangSmith.
@@ -190,3 +194,6 @@ async def feedback(feedback: Feedback) -> FeedbackResponse:
         **kwargs,
     )
     return FeedbackResponse()
+
+
+app.include_router(router)


### PR DESCRIPTION
The current API places Bearer authentication at the middleware layer, which prevents direct access to the API documentation from a browser when an API KEY is set.
Additionally, the need to provide this API KEY is not mentioned in the API documentation.

I used the built-in features of FastAPI to implement this functionality and removed the middleware that provided the same functionality.
Additionally, because I wanted to allow access to `docs`, `redoc`, and `openapi.json` without providing an API KEY, I set up an extra APIRouter.

docs:
![image](https://github.com/user-attachments/assets/c259df6f-772d-4363-afdc-3da0124d3ede)

redoc:
![image](https://github.com/user-attachments/assets/24c0cd77-d991-4a8b-bd6a-6ea30cefef35)


---

If you agree with this change, I can add the corresponding tests.
However, the existing tests will fail when an API KEY is provided, so the old tests will need to be adjusted accordingly.

I believe that as the codebase grows, this project needs some refactoring.
For example, tests should have a separate test folder, and routers should have their own modules.