### PR TITLE
Fix code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Annotated, Any
 from uuid import uuid4
-
+import logging
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -130,7 +130,9 @@ async def message_generator(user_input: StreamInput) -> AsyncGenerator[str, None
                     chat_message = ChatMessage.from_langchain(message)
                     chat_message.run_id = str(run_id)
                 except Exception as e:
-                    yield f"data: {json.dumps({'type': 'error', 'content': f'Error parsing message: {e}'})}\n\n"
+                    # Log the detailed exception message
+                    logging.error(f"Error parsing message: {e}")
+                    yield f"data: {json.dumps({'type': 'error', 'content': 'An internal error has occurred while parsing the message.'})}\n\n"
                     continue
                 # LangGraph re-sends the input message, which feels weird, so drop it
                 if chat_message.type == "human" and chat_message.content == user_input.message:


### PR DESCRIPTION
Fixes [https://github.com/JoshuaC215/agent-service-toolkit/security/code-scanning/1](https://github.com/JoshuaC215/agent-service-toolkit/security/code-scanning/1)

To fix the problem, we need to ensure that the exception message is not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the code to log the exception and yield a generic error message.

- Modify the `message_generator` function to log the exception instead of including it in the response.
- Ensure that the logging mechanism is in place to capture the detailed error message for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
