### PR TITLE
Remove langchain dependency from schema.ChatMessage

### DIFF
--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -8,7 +8,10 @@ ENV UV_COMPILE_BYTECODE=1
 COPY pyproject.toml .
 COPY uv.lock .
 RUN pip install --no-cache-dir uv
-RUN uv sync --frozen --no-install-project --no-dev
+# RUN uv sync --frozen --no-install-project --no-dev
+# Test expected deps in Streamlit Cloud
+COPY requirements.txt .
+RUN uv pip install --system -r requirements.txt
 
 COPY src/client/ ./client/
 COPY src/schema/ ./schema/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@
 # USE PYPROJECT.TOML AND UV.LOCK FOR YOUR OWN INSTALL!
 
 httpx~=0.26.0
-langchain-core~=0.3
 pydantic ~=2.9.0
 streamlit~=1.37.0

--- a/src/run_client.py
+++ b/src/run_client.py
@@ -17,6 +17,7 @@ async def amain() -> None:
         if isinstance(message, str):
             print(message, flush=True, end="|")
         elif isinstance(message, ChatMessage):
+            print("\n", flush=True)
             message.pretty_print()
         else:
             print(f"ERROR: Unknown type - {type(message)}")
@@ -36,6 +37,7 @@ for message in client.stream("Share a quick fun fact?"):
     if isinstance(message, str):
         print(message, flush=True, end="|")
     elif isinstance(message, ChatMessage):
+        print("\n", flush=True)
         message.pretty_print()
     else:
         print(f"ERROR: Unknown type - {type(message)}")

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -6,7 +6,6 @@ from schema.schema import (
     FeedbackResponse,
     StreamInput,
     UserInput,
-    convert_message_content_to_string,
 )
 
 __all__ = [
@@ -17,5 +16,4 @@ __all__ = [
     "FeedbackResponse",
     "ChatHistoryInput",
     "ChatHistory",
-    "convert_message_content_to_string",
 ]

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 
-from langchain_core.messages import ToolCall
 from pydantic import BaseModel, Field
+from typing_extensions import NotRequired, TypedDict
 
 
 class UserInput(BaseModel):
@@ -30,6 +30,18 @@ class StreamInput(UserInput):
         description="Whether to stream LLM tokens to the client.",
         default=True,
     )
+
+
+class ToolCall(TypedDict):
+    """Represents a request to call a tool."""
+
+    name: str
+    """The name of the tool to be called."""
+    args: dict[str, Any]
+    """The arguments to the tool call."""
+    id: str | None
+    """An identifier associated with the tool call."""
+    type: NotRequired[Literal["tool_call"]]
 
 
 class ChatMessage(BaseModel):

--- a/src/schema/test_schema.py
+++ b/src/schema/test_schema.py
@@ -3,33 +3,22 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from schema import ChatMessage
 
 
-def test_messages_to_langchain() -> None:
-    human_message = ChatMessage(type="human", content="Hello, world!")
-    lc_message = human_message.to_langchain()
-    assert isinstance(lc_message, HumanMessage)
-    assert lc_message.type == "human"
-    assert lc_message.content == "Hello, world!"
-
-
 def test_messages_from_langchain() -> None:
     lc_human_message = HumanMessage(content="Hello, world!")
     human_message = ChatMessage.from_langchain(lc_human_message)
     assert human_message.type == "human"
     assert human_message.content == "Hello, world!"
-    assert lc_human_message == human_message.to_langchain()
 
     lc_ai_message = AIMessage(content="Hello, world!")
     ai_message = ChatMessage.from_langchain(lc_ai_message)
     assert ai_message.type == "ai"
     assert ai_message.content == "Hello, world!"
-    assert lc_ai_message == ai_message.to_langchain()
 
     lc_tool_message = ToolMessage(content="Hello, world!", tool_call_id="123")
     tool_message = ChatMessage.from_langchain(lc_tool_message)
     assert tool_message.type == "tool"
     assert tool_message.content == "Hello, world!"
     assert tool_message.tool_call_id == "123"
-    assert lc_tool_message == tool_message.to_langchain()
 
     lc_system_message = SystemMessage(content="Hello, world!")
     try:
@@ -53,4 +42,3 @@ def test_messages_tool_calls() -> None:
     assert ai_message.tool_calls[0]["id"] == "call_Jja7"
     assert ai_message.tool_calls[0]["name"] == "test_tool"
     assert ai_message.tool_calls[0]["args"] == {"x": 1, "y": 2}
-    assert lc_ai_message == ai_message.to_langchain()

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from langchain_core._api import LangChainBetaWarning
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.graph.state import CompiledStateGraph
@@ -63,9 +63,8 @@ router = APIRouter(dependencies=bearer_depend)
 def _parse_input(user_input: UserInput) -> tuple[dict[str, Any], str]:
     run_id = uuid4()
     thread_id = user_input.thread_id or str(uuid4())
-    input_message = ChatMessage(type="human", content=user_input.message)
     kwargs = {
-        "input": {"messages": [input_message.to_langchain()]},
+        "input": {"messages": [HumanMessage(content=user_input.message)]},
         "config": RunnableConfig(
             configurable={"thread_id": thread_id, "model": user_input.model}, run_id=run_id
         ),

--- a/src/service/test_utils.py
+++ b/src/service/test_utils.py
@@ -1,28 +1,28 @@
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
 
-from schema import ChatMessage
+from service.utils import langchain_to_chat_message
 
 
 def test_messages_from_langchain() -> None:
     lc_human_message = HumanMessage(content="Hello, world!")
-    human_message = ChatMessage.from_langchain(lc_human_message)
+    human_message = langchain_to_chat_message(lc_human_message)
     assert human_message.type == "human"
     assert human_message.content == "Hello, world!"
 
     lc_ai_message = AIMessage(content="Hello, world!")
-    ai_message = ChatMessage.from_langchain(lc_ai_message)
+    ai_message = langchain_to_chat_message(lc_ai_message)
     assert ai_message.type == "ai"
     assert ai_message.content == "Hello, world!"
 
     lc_tool_message = ToolMessage(content="Hello, world!", tool_call_id="123")
-    tool_message = ChatMessage.from_langchain(lc_tool_message)
+    tool_message = langchain_to_chat_message(lc_tool_message)
     assert tool_message.type == "tool"
     assert tool_message.content == "Hello, world!"
     assert tool_message.tool_call_id == "123"
 
     lc_system_message = SystemMessage(content="Hello, world!")
     try:
-        _ = ChatMessage.from_langchain(lc_system_message)
+        _ = langchain_to_chat_message(lc_system_message)
     except ValueError as e:
         assert str(e) == "Unsupported message type: SystemMessage"
 
@@ -30,7 +30,7 @@ def test_messages_from_langchain() -> None:
 def test_message_run_id_usage() -> None:
     run_id = "847c6285-8fc9-4560-a83f-4e6285809254"
     lc_message = AIMessage(content="Hello, world!")
-    ai_message = ChatMessage.from_langchain(lc_message)
+    ai_message = langchain_to_chat_message(lc_message)
     ai_message.run_id = run_id
     assert ai_message.run_id == run_id
 
@@ -38,7 +38,7 @@ def test_message_run_id_usage() -> None:
 def test_messages_tool_calls() -> None:
     tool_call = ToolCall(name="test_tool", args={"x": 1, "y": 2}, id="call_Jja7")
     lc_ai_message = AIMessage(content="", tool_calls=[tool_call])
-    ai_message = ChatMessage.from_langchain(lc_ai_message)
+    ai_message = langchain_to_chat_message(lc_ai_message)
     assert ai_message.tool_calls[0]["id"] == "call_Jja7"
     assert ai_message.tool_calls[0]["name"] == "test_tool"
     assert ai_message.tool_calls[0]["args"] == {"x": 1, "y": 2}

--- a/src/service/utils.py
+++ b/src/service/utils.py
@@ -1,0 +1,76 @@
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    ToolMessage,
+)
+from langchain_core.messages import (
+    ChatMessage as LangchainChatMessage,
+)
+
+from schema import ChatMessage
+
+
+def convert_message_content_to_string(content: str | list[str | dict]) -> str:
+    if isinstance(content, str):
+        return content
+    text: list[str] = []
+    for content_item in content:
+        if isinstance(content_item, str):
+            text.append(content_item)
+            continue
+        if content_item["type"] == "text":
+            text.append(content_item["text"])
+    return "".join(text)
+
+
+def langchain_to_chat_message(message: BaseMessage) -> ChatMessage:
+    """Create a ChatMessage from a LangChain message."""
+    match message:
+        case HumanMessage():
+            human_message = ChatMessage(
+                type="human",
+                content=convert_message_content_to_string(message.content),
+            )
+            return human_message
+        case AIMessage():
+            ai_message = ChatMessage(
+                type="ai",
+                content=convert_message_content_to_string(message.content),
+            )
+            if message.tool_calls:
+                ai_message.tool_calls = message.tool_calls
+            if message.response_metadata:
+                ai_message.response_metadata = message.response_metadata
+            return ai_message
+        case ToolMessage():
+            tool_message = ChatMessage(
+                type="tool",
+                content=convert_message_content_to_string(message.content),
+                tool_call_id=message.tool_call_id,
+            )
+            return tool_message
+        case LangchainChatMessage():
+            if message.role == "custom":
+                custom_message = ChatMessage(
+                    type="custom",
+                    content="",
+                    custom_data=message.content[0],
+                )
+                return custom_message
+            else:
+                raise ValueError(f"Unsupported chat message role: {message.role}")
+        case _:
+            raise ValueError(f"Unsupported message type: {message.__class__.__name__}")
+
+
+def remove_tool_calls(content: str | list[str | dict]) -> str | list[str | dict]:
+    """Remove tool calls from content."""
+    if isinstance(content, str):
+        return content
+    # Currently only Anthropic models stream tool calls, using content item type tool_use.
+    return [
+        content_item
+        for content_item in content
+        if isinstance(content_item, str) or content_item["type"] != "tool_use"
+    ]


### PR DESCRIPTION
Remove the dependency to install LangChain to use the schema / client.

Most of the work was cleaning up the from_langchain / to_langchain methods on ChatMessage. The to_langchain code was removed, from_langchain was converted to service.utils.langchain_to_chat_message.

Verified it works by switching Dockerfile.app to only install the requirements.txt which no longer includes LC

"Vendored" a few small pieces of LangChain code to make this work:
- langchain_core.messages.BaseMessage.pretty_print added to ChatMessage
- ToolCall definition copied into schema