### PR TITLE
Add AWS Bedrock model support and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ With that said, there are several other interesting projects in this space that 
    # See: https://docs.anthropic.com/en/api/getting-started
    ANTHROPIC_API_KEY=your_anthropic_key
 
+   # Optional, to enable AWS Bedrock models Haiku
+   # See: https://docs.aws.amazon.com/bedrock/latest/userguide/setting-up.html
+   USE_AWS_BEDROCK=true
+
    # Optional, to enable simple header-based auth on the service
    AUTH_SECRET=any_string_you_choose
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "setuptools ~=74.0.0",
     "streamlit ~=1.37.0",
     "uvicorn ~=0.30.5",
+    "langchain-aws>=0.2.6",
 ]
 
 [project.optional-dependencies]

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -1,10 +1,10 @@
 import os
-
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
 from langchain_openai import ChatOpenAI
+from langchain_aws import ChatBedrock
 
 # NOTE: models with streaming=True will send tokens as they are generated
 # if the /stream endpoint is called with stream_tokens=True (the default)
@@ -21,9 +21,13 @@ if os.getenv("ANTHROPIC_API_KEY") is not None:
     models["claude-3-haiku"] = ChatAnthropic(
         model="claude-3-haiku-20240307", temperature=0.5, streaming=True
     )
+if os.getenv("USE_AWS_BEDROCK") == "true":
+    models["bedrock-haiku"] = ChatBedrock(
+        model_id="anthropic.claude-3-5-haiku-20241022-v1:0", temperature=0.5
+    )
 
 if not models:
-    print("No LLM available. Please set API keys to enable at least one LLM.")
+    print("No LLM available. Please set API keys to enable at least one LLM or enable Bedrock with USE_BEDROCK=true.")
     if os.getenv("MODE") == "dev":
-        print("FastAPI initialized failed. Please use Ctrl + C to exit uvicorn.")
+        print("FastAPI initialization failed. Please use Ctrl + C to exit uvicorn.")
     exit(1)

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -27,7 +27,7 @@ if os.getenv("USE_AWS_BEDROCK") == "true":
     )
 
 if not models:
-    print("No LLM available. Please set API keys to enable at least one LLM or enable Bedrock with USE_BEDROCK=true.")
+    print("No LLM available. Please set API keys to enable at least one LLM or enable Bedrock with USE_AWS_BEDROCK=true.")
     if os.getenv("MODE") == "dev":
         print("FastAPI initialization failed. Please use Ctrl + C to exit uvicorn.")
     exit(1)

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -1,10 +1,11 @@
 import os
+
 from langchain_anthropic import ChatAnthropic
+from langchain_aws import ChatBedrock
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_groq import ChatGroq
 from langchain_openai import ChatOpenAI
-from langchain_aws import ChatBedrock
 
 # NOTE: models with streaming=True will send tokens as they are generated
 # if the /stream endpoint is called with stream_tokens=True (the default)

--- a/src/agents/models.py
+++ b/src/agents/models.py
@@ -27,7 +27,7 @@ if os.getenv("USE_AWS_BEDROCK") == "true":
     )
 
 if not models:
-    print("No LLM available. Please set API keys to enable at least one LLM or enable Bedrock with USE_AWS_BEDROCK=true.")
+    print("No LLM available. Please set environment variables to enable at least one LLM.")
     if os.getenv("MODE") == "dev":
         print("FastAPI initialization failed. Please use Ctrl + C to exit uvicorn.")
     exit(1)

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -68,7 +68,7 @@ async def main() -> None:
         "Gemini 1.5 Flash (streaming)": "gemini-1.5-flash",
         "Claude 3 Haiku (streaming)": "claude-3-haiku",
         "llama-3.1-70b on Groq": "llama-3.1-70b",
-        "AWS Bedrock Haiku (streaming)": "bedrock-haiku"
+        "AWS Bedrock Haiku (streaming)": "bedrock-haiku",
     }
     # Config options
     with st.sidebar:

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -65,9 +65,10 @@ async def main() -> None:
 
     models = {
         "OpenAI GPT-4o-mini (streaming)": "gpt-4o-mini",
-        "Gemini 1.5 Flash (streaming)": "gemini-1.5-flash",
+        "Gemini 1.5 Flash (streaming)": "gemini-1.5-flash", 
         "Claude 3 Haiku (streaming)": "claude-3-haiku",
         "llama-3.1-70b on Groq": "llama-3.1-70b",
+        "AWS Bedrock Haiku (streaming)": "bedrock-haiku"
     }
     # Config options
     with st.sidebar:

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -65,7 +65,7 @@ async def main() -> None:
 
     models = {
         "OpenAI GPT-4o-mini (streaming)": "gpt-4o-mini",
-        "Gemini 1.5 Flash (streaming)": "gemini-1.5-flash", 
+        "Gemini 1.5 Flash (streaming)": "gemini-1.5-flash",
         "Claude 3 Haiku (streaming)": "claude-3-haiku",
         "llama-3.1-70b on Groq": "llama-3.1-70b",
         "AWS Bedrock Haiku (streaming)": "bedrock-haiku"

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "langchain-anthropic" },
+    { name = "langchain-aws" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -54,6 +55,7 @@ requires-dist = [
     { name = "fastapi", specifier = "~=0.115.0" },
     { name = "httpx", specifier = "~=0.26.0" },
     { name = "langchain-anthropic", specifier = "~=0.2.0" },
+    { name = "langchain-aws", specifier = ">=0.2.6" },
     { name = "langchain-community", specifier = "~=0.3.0" },
     { name = "langchain-core", specifier = "~=0.3.0" },
     { name = "langchain-google-genai", specifier = "~=2.0.0" },
@@ -270,6 +272,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/57/a6a1721eff09598fb01f3c7cda070c1b6a0f12d63c83236edf79a440abcc/blinker-1.8.2.tar.gz", hash = "sha256:8f77b09d3bf7c795e969e9486f39c2c5e9c39d4ee07424be2bc594ece9642d83", size = 23161 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/2a/10164ed1f31196a2f7f3799368a821765c62851ead0e630ab52b8e14b4d0/blinker-1.8.2-py3-none-any.whl", hash = "sha256:1779309f71bf239144b9399d06ae925637cf6634cf6bd131104184531bf67c01", size = 9456 },
+]
+
+[[package]]
+name = "boto3"
+version = "1.35.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/e9/52e1db9abfc9ebd1ce8d7a0600f74b226c0b243e78def2b5d59ff8efe594/boto3-1.35.54.tar.gz", hash = "sha256:7d9c359bbbc858a60b51c86328db813353c8bd1940212cdbd0a7da835291c2e1", size = 110991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/83/81c3d2199f2196493b1f67852e6361a082ca05dc5d976432b86808b7db82/boto3-1.35.54-py3-none-any.whl", hash = "sha256:2d5e160b614db55fbee7981001c54476cb827c441cef65b2fcb2c52a62019909", size = 139158 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.35.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/56/5eacd3dcecdbc36cb5695676c165430282f83cb86ffa75a1a65c34c084c5/botocore-1.35.54.tar.gz", hash = "sha256:131bb59ce59c8a939b31e8e647242d70cf11d32d4529fa4dca01feea1e891a76", size = 12920483 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/cd/e79c87014d0ed371335273cbf8a2bc1fdd6dd2071ba6cb9efedb6e311504/botocore-1.35.54-py3-none-any.whl", hash = "sha256:9cca1811094b6cdc144c2c063a3ec2db6d7c88194b04d4277cd34fc8e3473aff", size = 12708560 },
 ]
 
 [[package]]
@@ -936,6 +966,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1021,6 +1060,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-aws"
+version = "0.2.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "langchain-core" },
+    { name = "numpy" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/ff/5a225bd21480bf02d0a451516407f6b9127b4cf0208a69b318fd54618558/langchain_aws-0.2.6.tar.gz", hash = "sha256:73235e429267ba48a1c32a1c7f2e7ae356da5b4fd00cb3a53b6b24bf10b9985f", size = 73667 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/9f/2f5bb7fb3b9c2a145f79b878c2cf26be0dd84cc4c47e5c28253f2d2c7b2e/langchain_aws-0.2.6-py3-none-any.whl", hash = "sha256:b22c0046d5795bc4a2d5d09b45f25a359c7bd31961b206622ef22727e7891f26", size = 87634 },
+]
+
+[[package]]
 name = "langchain-community"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1044,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.1"
+version = "0.3.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1055,9 +1109,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/97/76ae5dabedcb54a3dd987661ae804ab8dadf11f2ccfb20045cbcf4a113b0/langchain_core-0.3.1.tar.gz", hash = "sha256:c4609eba3969df633fb3e3f3378f51bac8b85cdea18f7cb09a1f44c6a1d07723", size = 324223 }
+sdist = { url = "https://files.pythonhosted.org/packages/44/c5/88b55a6000e816864753dbdc12b19f77a366102959ef71869b40287cb082/langchain_core-0.3.15.tar.gz", hash = "sha256:b1a29787a4ffb7ec2103b4e97d435287201da7809b369740dd1e32f176325aba", size = 327855 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/04/608e974a8ae6f125629bdbe8c4ba02364fb8ff989e819e237c558d9c109a/langchain_core-0.3.1-py3-none-any.whl", hash = "sha256:52656baafd9f14163f112c2828b4c3099170a99861479cdbb8e8949f4153b5c5", size = 405147 },
+    { url = "https://files.pythonhosted.org/packages/cf/0e/9b0c2214a371e99d26586c7a61f8c8af5b1150d46c8fa10d9b58e3c5bfa2/langchain_core-0.3.15-py3-none-any.whl", hash = "sha256:3d4ca6dbb8ed396a6ee061063832a2451b0ce8c345570f7b086ffa7288e4fa29", size = 408721 },
 ]
 
 [[package]]
@@ -1169,17 +1223,18 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.1.122"
+version = "0.1.140"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "requests" },
+    { name = "requests-toolbelt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/86/d049cff8262150dd6f9df578c00d4bad38f48a0a0eb5d1b422d2aa2fc798/langsmith-0.1.122.tar.gz", hash = "sha256:56dff727ca529fe8df300e6e4759dc920efe10ab8cd602b4d6b51e33599214e6", size = 281357 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/fa/ef7c3857cf473bf6c29520a7b5f84b5b64ce4274aea0bae96d552d0e0ff4/langsmith-0.1.140.tar.gz", hash = "sha256:cb0a717d7b9e6d3145285d7ca0ab216e064cbe7a1ca4139fc04af57fb2315e70", size = 293742 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/24/9f62f5f56336f7cbdec63b5aba249c76cf583cc9e1f6932f604cf4348fc1/langsmith-0.1.122-py3-none-any.whl", hash = "sha256:9c9cde442d7321e8557f5c45c14b1b643b8aa28acc3f844d3a0021a9571aad7c", size = 289970 },
+    { url = "https://files.pythonhosted.org/packages/60/e6/9487d1bfea455424ad4dfb498bc5fa983c00a73915b529e97573c7576d35/langsmith-0.1.140-py3-none-any.whl", hash = "sha256:3de70183ae19a4ada4d77a8a9f336ff95ca0ead98215771033ee889a2889fe19", size = 304802 },
 ]
 
 [[package]]
@@ -2117,6 +2172,18 @@ socks = [
 ]
 
 [[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
+]
+
+[[package]]
 name = "rich"
 version = "13.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2236,6 +2303,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/7e/6b0a9ab30428a9e3d9607f6dd2e4fb743594d42bd1b6ba7b7b239acda921/ruff-0.6.5-py3-none-win32.whl", hash = "sha256:cf4d3fa53644137f6a4a27a2b397381d16454a1566ae5335855c187fbf67e4f5", size = 8012512 },
     { url = "https://files.pythonhosted.org/packages/d8/88/176f50162a219e3039f21e9e4323869fc62bf8d3afb4147a390d6c744bd8/ruff-0.6.5-py3-none-win_amd64.whl", hash = "sha256:3e42a57b58e3612051a636bc1ac4e6b838679530235520e8f095f7c44f706ff9", size = 8804438 },
     { url = "https://files.pythonhosted.org/packages/67/a0/1b488bbe35a7ff8296fdea1ec1a9c2676cecc7e42bda63860f9397d59140/ruff-0.6.5-py3-none-win_arm64.whl", hash = "sha256:51935067740773afdf97493ba9b8231279e9beef0f2a8079188c4776c25688e0", size = 8179780 },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.10.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/a8/e0a98fd7bd874914f0608ef7c90ffde17e116aefad765021de0f012690a2/s3transfer-0.10.3.tar.gz", hash = "sha256:4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c", size = 144591 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/c0/b0fba8259b61c938c9733da9346b9f93e00881a9db22aafdd72f6ae0ec05/s3transfer-0.10.3-py3-none-any.whl", hash = "sha256:263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d", size = 82625 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes changes to add support for AWS Bedrock models and update dependencies accordingly. The most important changes include updates to configuration files, dependency management, and model initialization logic.

### Support for AWS Bedrock Models:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114-R117): Added instructions for enabling AWS Bedrock models with a new `USE_AWS_BEDROCK` environment variable.
* [`src/agents/models.py`](diffhunk://#diff-40370f67f79320e3bdc1a5067ad6bcb62027f032e44028f6e50c102a83fd0dd1L2-R7): Imported `ChatBedrock` from `langchain_aws` and added logic to initialize the `bedrock-haiku` model when `USE_AWS_BEDROCK` is set to true. [[1]](diffhunk://#diff-40370f67f79320e3bdc1a5067ad6bcb62027f032e44028f6e50c102a83fd0dd1L2-R7) [[2]](diffhunk://#diff-40370f67f79320e3bdc1a5067ad6bcb62027f032e44028f6e50c102a83fd0dd1R24-R32)
* [`src/streamlit_app.py`](diffhunk://#diff-5335c95eda1850d822c155f25be94c31d0d7e492971278ada2c842f05be48dd1R71): Added "AWS Bedrock Haiku (streaming)" to the list of available models in the Streamlit app.

### Dependency Management:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R39): Added `langchain-aws` version 0.2.6 or higher to the list of dependencies.