### PR TITLE
Fix issue with ENV mismatch between app and service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,5 +30,5 @@ MODE=
 # OpenWeatherMap API key
 OPENWEATHERMAP_API_KEY=
 
-# Agent URL (used in Streamlit app, it usually should be the same as HOST:PORT)
-AGENT_URL=http://localhost:80
+# Agent URL: used in Streamlit app - if not set, defaults to http://{HOST}:{PORT}
+# AGENT_URL=http://localhost:80

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@
 
 httpx~=0.27.2
 pydantic ~=2.10.1
+python-dotenv ~=1.0.1
 streamlit~=1.40.1

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -3,6 +3,7 @@ import os
 from collections.abc import AsyncGenerator
 
 import streamlit as st
+from dotenv import load_dotenv
 from pydantic import ValidationError
 from streamlit.runtime.scriptrunner import get_script_run_ctx
 
@@ -57,9 +58,13 @@ async def main() -> None:
         st.rerun()
 
     if "agent_client" not in st.session_state:
-        st.session_state.agent_client = AgentClient(
-            base_url=os.getenv("AGENT_URL", "http://localhost")
-        )
+        load_dotenv()
+        agent_url = os.getenv("AGENT_URL")
+        if not agent_url:
+            host = os.getenv("HOST", "0.0.0.0")
+            port = os.getenv("PORT", 80)
+            agent_url = f"http://{host}:{port}"
+        st.session_state.agent_client = AgentClient(base_url=agent_url)
     agent_client: AgentClient = st.session_state.agent_client
 
     if "thread_id" not in st.session_state:


### PR DESCRIPTION
With #86 we introduced much easier cases where the ENV setup of the streamlit app and the service could get out of sync, specifically with setting the host and port of the service.

This should fix some of those cases so you get the expected behavior more easily especially right after cloning the repo and doing minimal tweaks on `.env`.

Closes #108