### PR TITLE
Migrate from requirements.txt to a client dependency group

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -78,14 +78,14 @@ jobs:
             done
           '
 
-      - name: Set up Python 3.12
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version-file: "pyproject.toml"
       - name: Install uv
-        uses: astral-sh/setup-uv@v2
+        uses: astral-sh/setup-uv@v4
         with:
-          version: "0.4.12"
+          version: "0.5.5"
       - name: Install ONLY CLIENT dependencies with uv
         run: |
           uv sync --frozen --only-group client --only-group dev

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -88,7 +88,7 @@ jobs:
           version: "0.4.12"
       - name: Install ONLY CLIENT dependencies with uv
         run: |
-          uv pip install -r requirements.txt
+          uv sync --frozen --only-group client --only-group dev
           uv pip install pytest pytest-env
         env:
           UV_SYSTEM_PYTHON: 1

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -89,11 +89,10 @@ jobs:
       - name: Install ONLY CLIENT dependencies with uv
         run: |
           uv sync --frozen --only-group client --only-group dev
-          uv pip install pytest pytest-env
         env:
           UV_SYSTEM_PYTHON: 1
       - name: Run integration tests
-        run: pytest tests/integration -v --run-docker
+        run: uv run pytest tests/integration -v --run-docker
 
       - name: Clean up containers
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install uv
-      uses: astral-sh/setup-uv@v2
+      uses: astral-sh/setup-uv@v4
       with:
-        version: "0.5.4"
+        version: "0.5.5"
     - name: Install dependencies with uv
       run: |
         uv sync --frozen

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         version: "0.5.4"
     - name: Install dependencies with uv
       run: |
-        uv sync --frozen --extra dev
+        uv sync --frozen
       env:
         UV_SYSTEM_PYTHON: 1
     - name: Lint and format with ruff

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You can also run the agent service and the Streamlit app locally without Docker,
 
    ```sh
    pip install uv
-   uv sync --frozen --extra dev
+   uv sync --frozen
    source .venv/bin/activate
    ```
 
@@ -164,7 +164,7 @@ Currently the tests need to be run using the local development without Docker se
 
    ```sh
    pip install uv
-   uv sync --frozen --extra dev
+   uv sync --frozen
    pre-commit install
    ```
 

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -8,10 +8,8 @@ ENV UV_COMPILE_BYTECODE=1
 COPY pyproject.toml .
 COPY uv.lock .
 RUN pip install --no-cache-dir uv
-# RUN uv sync --frozen --no-install-project --no-dev
-# Test expected deps in Streamlit Cloud
-COPY requirements.txt .
-RUN uv pip install --system -r requirements.txt
+# Only install the client dependencies
+RUN uv sync --frozen --only-group client
 
 COPY src/client/ ./client/
 COPY src/schema/ ./schema/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,13 +41,23 @@ dependencies = [
     "uvicorn ~=0.32.1",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pre-commit",
     "pytest",
     "pytest-env",
     "pytest-asyncio",
     "ruff",
+]
+
+# Group for the minimal dependencies to run just the client and Streamlit app.
+# These are also installed in the default dependencies.
+# To install run: `uv sync --frozen --only-group client`
+client = [
+    "httpx~=0.27.2",
+    "pydantic ~=2.10.1",
+    "python-dotenv ~=1.0.1",
+    "streamlit~=1.40.1",
 ]
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-# IMPORTANT: This is only used for the Streamlit app deployment
-# to Streamlit Community Cloud, since it doesn't have support for uv.
-# USE PYPROJECT.TOML AND UV.LOCK FOR YOUR OWN INSTALL!
-
-httpx~=0.27.2
-pydantic ~=2.10.1
-python-dotenv ~=1.0.1
-streamlit~=1.40.1

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,13 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
+client = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "streamlit" },
+]
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
@@ -62,20 +68,30 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = "~=2.0.1" },
     { name = "langsmith", specifier = "~=0.1.145" },
     { name = "numexpr", specifier = "~=2.10.1" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyarrow", specifier = ">=18.1.0" },
     { name = "pydantic", specifier = "~=2.10.1" },
     { name = "pydantic-settings", specifier = "~=2.6.1" },
     { name = "pyowm", specifier = "~=3.3.0" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "pytest-env", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = "~=1.0.1" },
-    { name = "ruff", marker = "extra == 'dev'" },
     { name = "setuptools", specifier = "~=75.6.0" },
     { name = "streamlit", specifier = "~=1.40.1" },
     { name = "tiktoken", specifier = ">=0.8.0" },
     { name = "uvicorn", specifier = "~=0.32.1" },
+]
+
+[package.metadata.requires-dev]
+client = [
+    { name = "httpx", specifier = "~=0.27.2" },
+    { name = "pydantic", specifier = "~=2.10.1" },
+    { name = "python-dotenv", specifier = "~=1.0.1" },
+    { name = "streamlit", specifier = "~=1.40.1" },
+]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-env" },
+    { name = "ruff" },
 ]
 
 [[package]]


### PR DESCRIPTION
Streamlit Community Cloud now supports installing dependencies from `uv.lock` (https://github.com/streamlit/streamlit/issues/9502). With this update, I no longer need to maintain a separate `requirements.txt` file just for streamlit (which was confusing and error prone). However, I still want to keep track of the minimal dependencies to run the client and app separate from the service.

This PR:
- Removes `requirements.txt` which was tracking the client-only dependencies used in Streamlit Cloud
- Adds a dependency group ([PEP 735](https://peps.python.org/pep-0735/)) for tracking the client dependencies, and use that to install the setup for the test-docker Github Action. This uses the `--only-group` flag in uv sync ([ref](https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies))
- This also migrates the `dev` group from an extra to a dependency group, following the best practice and making the default `--dev` / `--no-dev` behavior work as expected.