### PR TITLE
Add an endpoint for service metadata and use it to configure the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,20 +57,21 @@ docker compose watch
 1. **Multiple Agent Support**: Run multiple agents in the service and call by URL path
 1. **Asynchronous Design**: Utilizes async/await for efficient handling of concurrent requests.
 1. **Feedback Mechanism**: Includes a star-based feedback system integrated with LangSmith.
+1. **Dynamic Metadata**: `/info` endpoint provides dynamically configured metadata about the service and available agents and models.
 1. **Docker Support**: Includes Dockerfiles and a docker compose file for easy development and deployment.
+1. **Testing**: Includes robust unit and integration tests for the full repo.
 
 ### Key Files
 
 The repository is structured as follows:
 
-- `src/agents/research_assistant.py`: Defines the main LangGraph agent
-- `src/agents/llama_guard.py`: Defines the LlamaGuard content moderation
-- `src/agents/models.py`: Configures available models based on ENV
-- `src/agents/agents.py`: Mapping of all agents provided by the service
-- `src/schema/schema.py`: Defines the protocol schema
+- `src/agents/`: Defines several agents with different capabilities
+- `src/schema/`: Defines the protocol schema
+- `src/core/`: Core modules including LLM definition and settings
 - `src/service/service.py`: FastAPI service to serve the agents
 - `src/client/client.py`: Client to interact with the agent service
 - `src/streamlit_app.py`: Streamlit app providing a chat interface
+- `tests/`: Unit and integration tests
 
 ## Why LangGraph?
 
@@ -213,7 +214,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 - [x] Add more sophisticated tools for the research assistant
 - [x] Increase test coverage and add CI pipeline
 - [x] Add support for multiple agents running on the same service, including non-chat agent
-- [ ] Deployment instructions and configuration for cloud providers
+- [x] Service metadata endpoint `/info` and dynamic app configuration
 - [ ] More ideas? File an issue or create a discussion!
 
 ## License

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,3 +1,3 @@
-from agents.agents import DEFAULT_AGENT, agents
+from agents.agents import DEFAULT_AGENT, get_agent, get_all_agent_info
 
-__all__ = ["agents", "DEFAULT_AGENT"]
+__all__ = ["get_agent", "get_all_agent_info", "DEFAULT_AGENT"]

--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -1,14 +1,35 @@
+from dataclasses import dataclass
+
 from langgraph.graph.state import CompiledStateGraph
 
 from agents.bg_task_agent.bg_task_agent import bg_task_agent
 from agents.chatbot import chatbot
 from agents.research_assistant import research_assistant
+from schema import AgentInfo
 
 DEFAULT_AGENT = "research-assistant"
 
 
-agents: dict[str, CompiledStateGraph] = {
-    "chatbot": chatbot,
-    "research-assistant": research_assistant,
-    "bg-task-agent": bg_task_agent,
+@dataclass
+class Agent:
+    description: str
+    graph: CompiledStateGraph
+
+
+agents: dict[str, Agent] = {
+    "chatbot": Agent(description="A simple chatbot.", graph=chatbot),
+    "research-assistant": Agent(
+        description="A research assistant with web search and calculator.", graph=research_assistant
+    ),
+    "bg-task-agent": Agent(description="A background task agent.", graph=bg_task_agent),
 }
+
+
+def get_agent(agent_id: str) -> CompiledStateGraph:
+    return agents[agent_id].graph
+
+
+def get_all_agent_info() -> list[AgentInfo]:
+    return [
+        AgentInfo(key=agent_id, description=agent.description) for agent_id, agent in agents.items()
+    ]

--- a/src/agents/research_assistant.py
+++ b/src/agents/research_assistant.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from langchain_community.tools import DuckDuckGoSearchResults, OpenWeatherMapQueryRun
+from langchain_community.utilities import OpenWeatherMapAPIWrapper
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSerializable
@@ -31,7 +32,10 @@ tools = [web_search, calculator]
 # Add weather tool if API key is set
 # Register for an API key at https://openweathermap.org/api/
 if settings.OPENWEATHERMAP_API_KEY:
-    tools.append(OpenWeatherMapQueryRun(name="Weather"))
+    wrapper = OpenWeatherMapAPIWrapper(
+        openweathermap_api_key=settings.OPENWEATHERMAP_API_KEY.get_secret_value()
+    )
+    tools.append(OpenWeatherMapQueryRun(name="Weather", api_wrapper=wrapper))
 
 current_date = datetime.now().strftime("%B %d, %Y")
 instructions = f"""

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -1,3 +1,3 @@
-from client.client import AgentClient
+from client.client import AgentClient, AgentClientError
 
-__all__ = ["AgentClient"]
+__all__ = ["AgentClient", "AgentClientError"]

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
 
     # If DEFAULT_MODEL is None, it will be set in model_post_init
     DEFAULT_MODEL: AllModelEnum | None = None  # type: ignore[assignment]
+    AVAILABLE_MODELS: set[AllModelEnum] = set()  # type: ignore[assignment]
 
     OPENWEATHERMAP_API_KEY: SecretStr | None = None
 
@@ -68,23 +69,34 @@ class Settings(BaseSettings):
         if not active_keys:
             raise ValueError("At least one LLM API key must be provided.")
 
-        if self.DEFAULT_MODEL is None:
-            first_provider = next(iter(active_keys))
-            match first_provider:
+        for provider in active_keys:
+            match provider:
                 case Provider.OPENAI:
-                    self.DEFAULT_MODEL = OpenAIModelName.GPT_4O_MINI
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = OpenAIModelName.GPT_4O_MINI
+                    self.AVAILABLE_MODELS.update(set(OpenAIModelName))
                 case Provider.ANTHROPIC:
-                    self.DEFAULT_MODEL = AnthropicModelName.HAIKU_3
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = AnthropicModelName.HAIKU_3
+                    self.AVAILABLE_MODELS.update(set(AnthropicModelName))
                 case Provider.GOOGLE:
-                    self.DEFAULT_MODEL = GoogleModelName.GEMINI_15_FLASH
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = GoogleModelName.GEMINI_15_FLASH
+                    self.AVAILABLE_MODELS.update(set(GoogleModelName))
                 case Provider.GROQ:
-                    self.DEFAULT_MODEL = GroqModelName.LLAMA_31_8B
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = GroqModelName.LLAMA_31_8B
+                    self.AVAILABLE_MODELS.update(set(GroqModelName))
                 case Provider.AWS:
-                    self.DEFAULT_MODEL = AWSModelName.BEDROCK_HAIKU
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = AWSModelName.BEDROCK_HAIKU
+                    self.AVAILABLE_MODELS.update(set(AWSModelName))
                 case Provider.FAKE:
-                    self.DEFAULT_MODEL = FakeModelName.FAKE
+                    if self.DEFAULT_MODEL is None:
+                        self.DEFAULT_MODEL = FakeModelName.FAKE
+                    self.AVAILABLE_MODELS.update(set(FakeModelName))
                 case _:
-                    raise ValueError(f"Unknown provider: {first_provider}")
+                    raise ValueError(f"Unknown provider: {provider}")
 
     @computed_field
     @property

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -65,7 +65,7 @@ class Settings(BaseSettings):
             Provider.AWS: self.USE_AWS_BEDROCK,
             Provider.FAKE: self.USE_FAKE_MODEL,
         }
-        active_keys = {k for k, v in api_keys.items() if v}
+        active_keys = [k for k, v in api_keys.items() if v]
         if not active_keys:
             raise ValueError("At least one LLM API key must be provided.")
 

--- a/src/run_client.py
+++ b/src/run_client.py
@@ -9,6 +9,9 @@ async def amain() -> None:
     #### ASYNC ####
     client = AgentClient(settings.BASE_URL)
 
+    print("Agent info:")
+    print(client.info)
+
     print("Chat example:")
     response = await client.ainvoke("Tell me a brief joke?", model="gpt-4o")
     response.pretty_print()
@@ -27,6 +30,9 @@ async def amain() -> None:
 def main() -> None:
     #### SYNC ####
     client = AgentClient(settings.BASE_URL)
+
+    print("Agent info:")
+    print(client.info)
 
     print("Chat example:")
     response = client.invoke("Tell me a brief joke?", model="gpt-4o")

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,18 +1,22 @@
 from schema.models import AllModelEnum
 from schema.schema import (
+    AgentInfo,
     ChatHistory,
     ChatHistoryInput,
     ChatMessage,
     Feedback,
     FeedbackResponse,
+    ServiceMetadata,
     StreamInput,
     UserInput,
 )
 
 __all__ = [
+    "AgentInfo",
     "AllModelEnum",
     "UserInput",
     "ChatMessage",
+    "ServiceMetadata",
     "StreamInput",
     "Feedback",
     "FeedbackResponse",

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -6,6 +6,26 @@ from typing_extensions import TypedDict
 from schema.models import AllModelEnum
 
 
+class AgentInfo(BaseModel):
+    """Info about an available agent."""
+
+    key: str = Field(
+        description="Agent key.",
+        examples=["research-assistant"],
+    )
+    description: str = Field(
+        description="Description of the agent.",
+        examples=["A research assistant for generating research papers."],
+    )
+
+
+class ServiceMetadata(BaseModel):
+    """Metadata about the service including available agents and models."""
+
+    agents: list[AgentInfo]
+    models: set[AllModelEnum]
+
+
 class UserInput(BaseModel):
     """Basic user input for the agent."""
 

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -24,6 +24,8 @@ class ServiceMetadata(BaseModel):
 
     agents: list[AgentInfo]
     models: set[AllModelEnum]
+    default_agent: str
+    default_model: AllModelEnum
 
 
 class UserInput(BaseModel):

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -23,7 +23,7 @@ class ServiceMetadata(BaseModel):
     """Metadata about the service including available agents and models."""
 
     agents: list[AgentInfo]
-    models: set[AllModelEnum]
+    models: list[AllModelEnum]
     default_agent: str
     default_model: AllModelEnum
 

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -24,6 +24,7 @@ from schema import (
     ChatMessage,
     Feedback,
     FeedbackResponse,
+    ServiceMetadata,
     StreamInput,
     UserInput,
 )
@@ -65,6 +66,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(lifespan=lifespan)
 router = APIRouter(dependencies=[Depends(verify_bearer)])
+
+
+@router.get("/info")
+async def info() -> ServiceMetadata:
+    models = list(settings.AVAILABLE_MODELS)
+    models.sort()
+    return ServiceMetadata(
+        agents=get_all_agent_info(),
+        models=models,
+        default_agent=DEFAULT_AGENT,
+        default_model=settings.DEFAULT_MODEL,
+    )
 
 
 def _parse_input(user_input: UserInput) -> tuple[dict[str, Any], UUID]:

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -16,7 +16,7 @@ from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.graph.state import CompiledStateGraph
 from langsmith import Client as LangsmithClient
 
-from agents import DEFAULT_AGENT, agents
+from agents import DEFAULT_AGENT, get_agent, get_all_agent_info
 from core import settings
 from schema import (
     ChatHistory,
@@ -55,8 +55,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Construct agent with Sqlite checkpointer
     # TODO: It's probably dangerous to share the same checkpointer on multiple agents
     async with AsyncSqliteSaver.from_conn_string("checkpoints.db") as saver:
-        for a in agents.values():
-            a.checkpointer = saver
+        agents = get_all_agent_info()
+        for a in agents:
+            agent = get_agent(a.key)
+            agent.checkpointer = saver
         yield
     # context manager will clean up the AsyncSqliteSaver on exit
 
@@ -87,7 +89,7 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
     Use thread_id to persist and continue a multi-turn conversation. run_id kwarg
     is also attached to messages for recording feedback.
     """
-    agent: CompiledStateGraph = agents[agent_id]
+    agent: CompiledStateGraph = get_agent(agent_id)
     kwargs, run_id = _parse_input(user_input)
     try:
         response = await agent.ainvoke(**kwargs)
@@ -107,7 +109,7 @@ async def message_generator(
 
     This is the workhorse method for the /stream endpoint.
     """
-    agent: CompiledStateGraph = agents[agent_id]
+    agent: CompiledStateGraph = get_agent(agent_id)
     kwargs, run_id = _parse_input(user_input)
 
     # Process streamed events from the graph and yield messages over the SSE stream.
@@ -220,7 +222,7 @@ def history(input: ChatHistoryInput) -> ChatHistory:
     Get chat history.
     """
     # TODO: Hard-coding DEFAULT_AGENT here is wonky
-    agent: CompiledStateGraph = agents[DEFAULT_AGENT]
+    agent: CompiledStateGraph = get_agent(DEFAULT_AGENT)
     try:
         state_snapshot = agent.get_state(
             config=RunnableConfig(

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -2,11 +2,25 @@ from unittest.mock import patch
 
 import pytest
 
+from schema import AgentInfo, ServiceMetadata
+from schema.models import OpenAIModelName
+
 
 @pytest.fixture
 def mock_agent_client(mock_env):
     """Fixture for creating a mock AgentClient with a clean environment."""
 
+    mock_info = ServiceMetadata(
+        default_agent="test-agent",
+        agents=[
+            AgentInfo(key="test-agent", description="Test agent"),
+            AgentInfo(key="chatbot", description="Chatbot"),
+        ],
+        default_model=OpenAIModelName.GPT_4O,
+        models=[OpenAIModelName.GPT_4O, OpenAIModelName.GPT_4O_MINI],
+    )
+
     with patch("client.AgentClient") as mock_agent_client:
         mock_agent_client_instance = mock_agent_client.return_value
+        mock_agent_client_instance.info = mock_info
         yield mock_agent_client_instance

--- a/tests/app/test_streamlit_app.py
+++ b/tests/app/test_streamlit_app.py
@@ -5,7 +5,7 @@ import pytest
 from streamlit.testing.v1 import AppTest
 
 from schema import ChatHistory, ChatMessage
-from schema.models import AnthropicModelName
+from schema.models import OpenAIModelName
 
 
 def test_app_simple_non_streaming(mock_agent_client):
@@ -45,9 +45,10 @@ def test_app_settings(mock_agent_client):
     )
 
     at.sidebar.toggle[0].set_value(False)  # Use Streaming = False
-    at.sidebar.radio[0].set_value("Claude 3 Haiku (streaming)")
-    assert mock_agent_client.agent == "research-assistant"
-    at.sidebar.selectbox[0].set_value("chatbot")
+    assert at.sidebar.selectbox[0].value == "gpt-4o"
+    assert mock_agent_client.agent == "test-agent"
+    at.sidebar.selectbox[0].set_value("gpt-4o-mini")
+    at.sidebar.selectbox[1].set_value("chatbot")
     at.chat_input[0].set_value(PROMPT).run()
     print(at)
 
@@ -61,7 +62,7 @@ def test_app_settings(mock_agent_client):
     assert mock_agent_client.agent == "chatbot"
     mock_agent_client.ainvoke.assert_called_with(
         message=PROMPT,
-        model=AnthropicModelName.HAIKU_3,
+        model=OpenAIModelName.GPT_4O_MINI,
         thread_id="test session id",
     )
     assert not at.exception

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -6,4 +6,6 @@ from client import AgentClient
 @pytest.fixture
 def agent_client(mock_env):
     """Fixture for creating a test client with a clean environment."""
-    return AgentClient(base_url="http://test", agent="test-agent")
+    ac = AgentClient(base_url="http://test", get_info=False)
+    ac.update_agent("test-agent", verify=False)
+    return ac

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -3,9 +3,9 @@ import os
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from httpx import Response
+from httpx import Request, Response
 
-from client import AgentClient
+from client import AgentClient, AgentClientError
 from schema import AgentInfo, ChatHistory, ChatMessage, ServiceMetadata
 from schema.models import OpenAIModelName
 
@@ -47,9 +47,11 @@ def test_invoke(agent_client):
     ANSWER = "The weather is sunny."
 
     # Mock successful response
+    mock_request = Request("POST", "http://test/invoke")
     mock_response = Response(
         200,
         json={"type": "ai", "content": ANSWER},
+        request=mock_request,
     )
     with patch("httpx.post", return_value=mock_response):
         response = agent_client.invoke(QUESTION)
@@ -72,11 +74,11 @@ def test_invoke(agent_client):
         assert kwargs["json"]["thread_id"] == "test-thread"
 
     # Test error response
-    error_response = Response(500, text="Internal Server Error")
+    error_response = Response(500, text="Internal Server Error", request=mock_request)
     with patch("httpx.post", return_value=error_response):
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(AgentClientError) as exc:
             agent_client.invoke(QUESTION)
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -86,7 +88,8 @@ async def test_ainvoke(agent_client):
     ANSWER = "The weather is sunny."
 
     # Test successful response
-    mock_response = Response(200, json={"type": "ai", "content": ANSWER})
+    mock_request = Request("POST", "http://test/invoke")
+    mock_response = Response(200, json={"type": "ai", "content": ANSWER}, request=mock_request)
     with patch("httpx.AsyncClient.post", return_value=mock_response):
         response = await agent_client.ainvoke(QUESTION)
         assert isinstance(response, ChatMessage)
@@ -110,10 +113,11 @@ async def test_ainvoke(agent_client):
         assert kwargs["json"]["thread_id"] == "test-thread"
 
     # Test error response
-    with patch("httpx.AsyncClient.post", return_value=Response(500, text="Internal Server Error")):
-        with pytest.raises(Exception) as exc:
+    error_response = Response(500, text="Internal Server Error", request=mock_request)
+    with patch("httpx.AsyncClient.post", return_value=error_response):
+        with pytest.raises(AgentClientError) as exc:
             await agent_client.ainvoke(QUESTION)
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 def test_stream(agent_client):
@@ -135,6 +139,7 @@ def test_stream(agent_client):
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.iter_lines.return_value = events
+    mock_response.request = Request("POST", "http://test/stream")
     mock_response.__enter__ = Mock(return_value=mock_response)
     mock_response.__exit__ = Mock(return_value=None)
 
@@ -154,15 +159,16 @@ def test_stream(agent_client):
         assert final_message.content == FINAL_ANSWER
 
     # Test error response
-    error_response = Mock()
-    error_response.status_code = 500
-    error_response.text = "Internal Server Error"
-    error_response.__enter__ = Mock(return_value=error_response)
-    error_response.__exit__ = Mock(return_value=None)
-    with patch("httpx.stream", return_value=error_response):
-        with pytest.raises(Exception) as exc:
+    error_response = Response(
+        500, text="Internal Server Error", request=Request("POST", "http://test/stream")
+    )
+    error_response_mock = Mock()
+    error_response_mock.__enter__ = Mock(return_value=error_response)
+    error_response_mock.__exit__ = Mock(return_value=None)
+    with patch("httpx.stream", return_value=error_response_mock):
+        with pytest.raises(AgentClientError) as exc:
             list(agent_client.stream(QUESTION))
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -189,6 +195,7 @@ async def test_astream(agent_client):
     # Mock the streaming response
     mock_response = AsyncMock()
     mock_response.status_code = 200
+    mock_response.request = Request("POST", "http://test/stream")
     mock_response.aiter_lines = Mock(return_value=async_events())
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
 
@@ -214,18 +221,19 @@ async def test_astream(agent_client):
         assert final_message.content == FINAL_ANSWER
 
     # Test error response
-    error_response = AsyncMock()
-    error_response.status_code = 500
-    error_response.text = "Internal Server Error"
-    error_response.__aenter__ = AsyncMock(return_value=error_response)
+    error_response = Response(
+        500, text="Internal Server Error", request=Request("POST", "http://test/stream")
+    )
+    error_response_mock = AsyncMock()
+    error_response_mock.__aenter__ = AsyncMock(return_value=error_response)
 
-    mock_client.stream.return_value = error_response
+    mock_client.stream.return_value = error_response_mock
 
     with patch("httpx.AsyncClient", return_value=mock_client):
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(AgentClientError) as exc:
             async for _ in agent_client.astream(QUESTION):
                 pass
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 @pytest.mark.asyncio
@@ -237,7 +245,8 @@ async def test_acreate_feedback(agent_client):
     KWARGS = {"comment": "Great response!"}
 
     # Test successful response
-    with patch("httpx.AsyncClient.post", return_value=Response(200, json={})) as mock_post:
+    mock_response = Response(200, json={}, request=Request("POST", "http://test/feedback"))
+    with patch("httpx.AsyncClient.post", return_value=mock_response) as mock_post:
         await agent_client.acreate_feedback(RUN_ID, KEY, SCORE, KWARGS)
         # Verify request
         args, kwargs = mock_post.call_args
@@ -247,10 +256,13 @@ async def test_acreate_feedback(agent_client):
         assert kwargs["json"]["kwargs"] == KWARGS
 
     # Test error response
-    with patch("httpx.AsyncClient.post", return_value=Response(500, text="Internal Server Error")):
-        with pytest.raises(Exception) as exc:
+    error_response = Response(
+        500, text="Internal Server Error", request=Request("POST", "http://test/feedback")
+    )
+    with patch("httpx.AsyncClient.post", return_value=error_response):
+        with pytest.raises(AgentClientError) as exc:
             await agent_client.acreate_feedback(RUN_ID, KEY, SCORE)
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 def test_get_history(agent_client):
@@ -264,7 +276,7 @@ def test_get_history(agent_client):
     }
 
     # Mock successful response
-    mock_response = Response(200, json=HISTORY)
+    mock_response = Response(200, json=HISTORY, request=Request("POST", "http://test/history"))
     with patch("httpx.post", return_value=mock_response):
         history = agent_client.get_history(THREAD_ID)
         assert isinstance(history, ChatHistory)
@@ -273,11 +285,13 @@ def test_get_history(agent_client):
         assert history.messages[1].type == "ai"
 
     # Test error response
-    error_response = Response(500, text="Internal Server Error")
+    error_response = Response(
+        500, text="Internal Server Error", request=Request("POST", "http://test/history")
+    )
     with patch("httpx.post", return_value=error_response):
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(AgentClientError) as exc:
             agent_client.get_history(THREAD_ID)
-        assert "Error: 500" in str(exc.value)
+        assert "500 Internal Server Error" in str(exc.value)
 
 
 def test_info(agent_client):
@@ -291,7 +305,9 @@ def test_info(agent_client):
         default_model=OpenAIModelName.GPT_4O,
         models=[OpenAIModelName.GPT_4O, OpenAIModelName.GPT_4O_MINI],
     )
-    test_response = Response(200, json=test_info.model_dump())
+    test_response = Response(
+        200, json=test_info.model_dump(), request=Request("GET", "http://test/info")
+    )
 
     # Update an existing client with info
     with patch("httpx.get", return_value=test_response):
@@ -301,7 +317,7 @@ def test_info(agent_client):
     assert agent_client.agent == "custom-agent"
 
     # Test invalid update_agent
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(AgentClientError) as exc:
         agent_client.update_agent("unknown-agent")
     assert "Agent unknown-agent not found in available agents: custom-agent" in str(exc.value)
 
@@ -313,6 +329,6 @@ def test_info(agent_client):
 
     # Test error on invoke if no agent set
     agent_client = AgentClient(base_url="http://test", get_info=False)
-    with pytest.raises(Exception) as exc:
+    with pytest.raises(AgentClientError) as exc:
         agent_client.invoke("test")
     assert "No agent selected. Use update_agent() to select an agent." in str(exc.value)

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -40,6 +40,7 @@ def test_settings_with_openai_key():
         settings = Settings(_env_file=None)
         assert settings.OPENAI_API_KEY == SecretStr("test_key")
         assert settings.DEFAULT_MODEL == OpenAIModelName.GPT_4O_MINI
+        assert settings.AVAILABLE_MODELS == set(OpenAIModelName)
 
 
 def test_settings_with_anthropic_key():
@@ -47,6 +48,27 @@ def test_settings_with_anthropic_key():
         settings = Settings(_env_file=None)
         assert settings.ANTHROPIC_API_KEY == SecretStr("test_key")
         assert settings.DEFAULT_MODEL == AnthropicModelName.HAIKU_3
+        assert settings.AVAILABLE_MODELS == set(AnthropicModelName)
+
+
+def test_settings_with_multiple_api_keys():
+    with patch.dict(
+        os.environ,
+        {
+            "OPENAI_API_KEY": "test_openai_key",
+            "ANTHROPIC_API_KEY": "test_anthropic_key",
+        },
+        clear=True,
+    ):
+        settings = Settings(_env_file=None)
+        assert settings.OPENAI_API_KEY == SecretStr("test_openai_key")
+        assert settings.ANTHROPIC_API_KEY == SecretStr("test_anthropic_key")
+        # When multiple providers are available, OpenAI should be the default
+        assert settings.DEFAULT_MODEL == OpenAIModelName.GPT_4O_MINI
+        # Available models should include exactly all OpenAI and Anthropic models
+        expected_models = set(OpenAIModelName)
+        expected_models.update(set(AnthropicModelName))
+        assert settings.AVAILABLE_MODELS == expected_models
 
 
 def test_settings_base_url():

--- a/tests/integration/test_docker_e2e.py
+++ b/tests/integration/test_docker_e2e.py
@@ -1,4 +1,5 @@
 import pytest
+from streamlit.testing.v1 import AppTest
 
 from client import AgentClient
 
@@ -13,3 +14,24 @@ def test_service_with_fake_model():
     response = client.invoke("Tell me a joke?", model="fake")
     assert response.type == "ai"
     assert response.content == "This is a test response from the fake model."
+
+
+@pytest.mark.docker
+def test_service_with_app():
+    """Test the service using the app.
+
+    This test requires the service container to be running with USE_FAKE_MODEL=true
+    """
+    at = AppTest.from_file("../../src/streamlit_app.py").run()
+    assert at.chat_message[0].avatar == "assistant"
+    welcome = at.chat_message[0].markdown[0].value
+    assert welcome.startswith("Hello! I'm an AI-powered research assistant")
+    assert not at.exception
+
+    at.sidebar.selectbox[1].set_value("chatbot")
+    at.chat_input[0].set_value("What is the weather in Tokyo?").run()
+    assert at.chat_message[0].avatar == "user"
+    assert at.chat_message[0].markdown[0].value == "What is the weather in Tokyo?"
+    assert at.chat_message[1].avatar == "assistant"
+    assert at.chat_message[1].markdown[0].value == "This is a test response from the fake model."
+    assert not at.exception

--- a/tests/service/conftest.py
+++ b/tests/service/conftest.py
@@ -31,8 +31,8 @@ def mock_settings(mock_env):
 
 
 @pytest.fixture
-def mock_httpx_stream():
-    """Patch httpx.stream to use our test client."""
+def mock_httpx():
+    """Patch httpx.stream and httpx.get to use our test client."""
 
     with TestClient(app) as client:
 
@@ -41,5 +41,11 @@ def mock_httpx_stream():
             path = url.replace("http://localhost", "")
             return client.stream(method, path, **kwargs)
 
+        def mock_get(url: str, **kwargs):
+            # Strip the base URL since TestClient expects just the path
+            path = url.replace("http://localhost", "")
+            return client.get(path, **kwargs)
+
         with patch("httpx.stream", mock_stream):
-            yield
+            with patch("httpx.get", mock_get):
+                yield

--- a/tests/service/conftest.py
+++ b/tests/service/conftest.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi.testclient import TestClient
 from langchain_core.messages import AIMessage
 
-from agents import DEFAULT_AGENT
 from service import app
 
 
@@ -20,7 +19,7 @@ def mock_agent():
     agent_mock = AsyncMock()
     agent_mock.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="Test response")]})
     agent_mock.get_state = Mock()  # Default empty mock for get_state
-    with patch.dict("service.service.agents", {DEFAULT_AGENT: agent_mock}):
+    with patch("service.service.get_agent", Mock(return_value=agent_mock)):
         yield agent_mock
 
 

--- a/tests/service/test_service_e2e.py
+++ b/tests/service/test_service_e2e.py
@@ -84,7 +84,13 @@ def test_agent_stream(mock_httpx_stream):
 
     # Use stream to get intermediate responses
     messages = []
-    with patch("service.service.agents", {"static-agent": static_agent}):
+
+    def agent_lookup(agent_id):
+        if agent_id == "static-agent":
+            return static_agent
+        return None
+
+    with patch("service.service.get_agent", side_effect=agent_lookup):
         for response in client.stream("Test message", stream_tokens=False):
             if isinstance(response, ChatMessage):
                 messages.append(response)

--- a/tests/service/test_service_e2e.py
+++ b/tests/service/test_service_e2e.py
@@ -5,6 +5,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, MessagesState, StateGraph
 
+from agents.agents import Agent
 from agents.utils import CustomData
 from client import AgentClient
 from schema.schema import ChatMessage
@@ -78,9 +79,11 @@ agent.add_edge("static_messages", END)
 static_agent = agent.compile(checkpointer=MemorySaver())
 
 
-def test_agent_stream(mock_httpx_stream):
+def test_agent_stream(mock_httpx):
     """Test that streaming from our static agent works correctly with token streaming."""
-    client = AgentClient(agent="static-agent")
+    agent_meta = Agent(description="A static agent.", graph=static_agent)
+    with patch.dict("agents.agents.agents", {"static-agent": agent_meta}, clear=True):
+        client = AgentClient(agent="static-agent")
 
     # Use stream to get intermediate responses
     messages = []


### PR DESCRIPTION
This ended up being a big update!

- Introduce `schema.ServiceMetadata` which describes available agents, models, and default values based on the configuration (e.g. available LLM API keys)
- Introduce `/info` endpoint on the service to return the current metadata
- Update the `AgentClient` to retrieve the metadata by default and store it at `AgentClient.info` for use
- Update the Streamlit app to use the `agent_client.info` to set the available agents and models in the app settings
- While I was at it, refactored the error handling in `AgentClient` to be more idiomatic / robust / specific, and updated the app to give cleaner errors when there are connectivity issues
- Updated many tests to work based on all the changes above, and added tests for new functionality
- Now, with the dynamic config I could write an e2e integration tests that runs the app and hits the deployed service across docker containers 🎉 