### PR TITLE
Add Chat Sharing Dialog & BugFix Empty History

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -72,8 +72,11 @@ async def main() -> None:
             thread_id = get_script_run_ctx().session_id
             messages = []
         else:
-            history: ChatHistory = agent_client.get_history(thread_id=thread_id)
-            messages = history.messages
+            try:
+                messages: ChatHistory = agent_client.get_history(thread_id=thread_id).messages
+            except Exception:
+                st.error("No message history found for this Thread ID.")
+                messages = []
         st.session_state.messages = messages
         st.session_state.thread_id = thread_id
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -75,7 +75,7 @@ async def main() -> None:
         else:
             try:
                 messages: ChatHistory = agent_client.get_history(thread_id=thread_id).messages
-            except Exception:
+            except AgentClientError:
                 st.error("No message history found for this Thread ID.")
                 messages = []
         st.session_state.messages = messages
@@ -115,11 +115,6 @@ async def main() -> None:
             st.write(
                 "Prompts, responses and feedback in this app are anonymously recorded and saved to LangSmith for product evaluation and improvement purposes only."
             )
-
-        st.markdown(
-            f"Thread ID: **{st.session_state.thread_id}**",
-            help=f"Set URL query parameter ?thread_id={st.session_state.thread_id} to continue this conversation or use the share button below",
-        )
 
         @st.dialog("Share/resume chat")
         def share_chat_dialog() -> None:

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import urllib.parse
 from collections.abc import AsyncGenerator
 
 import streamlit as st
@@ -117,8 +118,24 @@ async def main() -> None:
 
         st.markdown(
             f"Thread ID: **{st.session_state.thread_id}**",
-            help=f"Set URL query parameter ?thread_id={st.session_state.thread_id} to continue this conversation",
+            help=f"Set URL query parameter ?thread_id={st.session_state.thread_id} to continue this conversation or use the share button below",
         )
+
+        @st.dialog("Share/resume chat")
+        def share_chat_dialog() -> None:
+            session = st.runtime.get_instance()._session_mgr.list_active_sessions()[0]
+            st_base_url = urllib.parse.urlunparse(
+                [session.client.request.protocol, session.client.request.host, "", "", "", ""]
+            )
+            # if it's not localhost, switch to https by default
+            if not st_base_url.startswith("https") and "localhost" not in st_base_url:
+                st_base_url = st_base_url.replace("http", "https")
+            chat_url = f"{st_base_url}?thread_id={st.session_state.thread_id}"
+            st.markdown(f"**Chat URL:**\n```text\n{chat_url}\n```")
+            st.info("Copy the above URL to share or revisit this chat")
+
+        if st.button(":material/upload: Share/resume chat", use_container_width=True):
+            share_chat_dialog()
 
         "[View the source code](https://github.com/JoshuaC215/agent-service-toolkit)"
         st.caption(

--- a/tests/app/test_streamlit_app.py
+++ b/tests/app/test_streamlit_app.py
@@ -73,7 +73,7 @@ def test_app_thread_id_history(mock_agent_client):
     """Test the thread_id is generated"""
 
     at = AppTest.from_file("../../src/streamlit_app.py").run()
-    assert at.sidebar.markdown[-2].value == "Thread ID: **test session id**"
+    assert at.session_state.thread_id == "test session id"
 
     # Reset and set thread_id
     at = AppTest.from_file("../../src/streamlit_app.py")
@@ -85,7 +85,7 @@ def test_app_thread_id_history(mock_agent_client):
     mock_agent_client.get_history.return_value = ChatHistory(messages=HISTORY)
     at.run()
     print(at)
-    assert at.sidebar.markdown[-2].value == "Thread ID: **1234**"
+    assert at.session_state.thread_id == "1234"
     mock_agent_client.get_history.assert_called_with(thread_id="1234")
     assert at.chat_message[0].avatar == "user"
     assert at.chat_message[0].markdown[0].value == "What is the weather?"


### PR DESCRIPTION
_[Originally #124 - thank you @fedebotu for this great contribution!!]_

This PR adds the following improvements:

## 1. Add Chat Sharing Dialog

Previously, a user had to manually copy the `thread_id` to the service URL and set it as a query parameter. Now, a new dialog appears that allows users to conveniently copy the full link for sharing/resuming chats:

![share-resume-chat](https://github.com/user-attachments/assets/174065b0-87b5-4736-afb8-1ef90997647c)

## 2. BugFix Empty History

If the user tried for any reason to open a new chat with a `thread_id` with no messages yet, the below error appeared:

![server-error-no-history](https://github.com/user-attachments/assets/45b76155-30d4-4f57-bd39-55ccb4eb6154)


This PR fixes this issue by simply checking whether there is any history. If there is not, a simple error popup appears, avoiding the crash:

![history-fix](https://github.com/user-attachments/assets/6b23f153-f90c-4941-8ac2-26b24e47abce)

