### PR TITLE
Fix run_agent.py script after module exports changed

### DIFF
--- a/src/run_agent.py
+++ b/src/run_agent.py
@@ -6,9 +6,9 @@ from langchain_core.runnables import RunnableConfig
 
 load_dotenv()
 
-from agents import DEFAULT_AGENT, agents  # noqa: E402
+from agents import DEFAULT_AGENT, get_agent  # noqa: E402
 
-agent = agents[DEFAULT_AGENT]
+agent = get_agent(DEFAULT_AGENT)
 
 
 async def main() -> None:


### PR DESCRIPTION
In an earlier PR we stopped exporting the `agents` dict, but it was still being referenced in `src/run_agent.py` (which does not have automated test coverage). This caused it to crash. The PR fixes it to use the correctly exported function.