### PR TITLE
Migrate defaults to HOST=0.0.0.0 PORT=8080

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,8 @@ USE_FAKE_MODEL=false
 DEFAULT_MODEL=
 
 # Web server configuration
-HOST=localhost
-PORT=80
+HOST=0.0.0.0
+PORT=8080
 
 # Authentication secret, HTTP bearer token header is required if set
 AUTH_SECRET=
@@ -32,4 +32,4 @@ MODE=
 OPENWEATHERMAP_API_KEY=
 
 # Agent URL: used in Streamlit app - if not set, defaults to http://{HOST}:{PORT}
-# AGENT_URL=http://localhost:80
+# AGENT_URL=http://0.0.0.0:8080

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,10 @@ jobs:
         env:
           UV_SYSTEM_PYTHON: 1
       - name: Run integration tests
-        run: uv run pytest tests/integration -v --run-docker
+        run: |
+          uv run pytest tests/integration -v --run-docker
+        env:
+          AGENT_URL: http://0.0.0.0
 
       - name: Clean up containers
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Confirm service starts correctly
         run: |
           timeout 30 bash -c '
-            while ! curl -s http://localhost/health; do
+            while ! curl -s http://0.0.0.0/health; do
               echo "Waiting for service to be ready..."
               docker logs service-container
               sleep 2
@@ -103,7 +103,7 @@ jobs:
           '
 
       - name: Run app container
-        run: docker run -d --name app-container --network host -e AGENT_URL=http://localhost agent-service-toolkit.app:${{ github.sha }}
+        run: docker run -d --name app-container --network host -e AGENT_URL=http://0.0.0.0 agent-service-toolkit.app:${{ github.sha }}
 
       - name: Confirm app starts correctly
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
           file: docker/Dockerfile.app
 
       - name: Start service container
-        run: docker run -d --name service-container --network host -e USE_FAKE_MODEL=true agent-service-toolkit.service:${{ github.sha }}
+        run: docker run -d --name service-container --network host -e USE_FAKE_MODEL=true -e PORT=80 agent-service-toolkit.service:${{ github.sha }}
 
       - name: Confirm service starts correctly
         run: |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For local development, we recommend using [docker compose watch](https://docs.do
 
 4. Access the Streamlit app by navigating to `http://localhost:8501` in your web browser.
 
-5. The agent service API will be available at `http://localhost:80`. You can also use the OpenAPI docs at `http://localhost:80/redoc`.
+5. The agent service API will be available at `http://0.0.0.0:8080`. You can also use the OpenAPI docs at `http://0.0.0.0:8080/redoc`.
 
 6. Use `docker compose down` to stop the services.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.service
     ports:
-      - "80:80"
+      - "8080:8080"
     env_file:
       - .env
     develop:
@@ -28,7 +28,7 @@ services:
     depends_on:
       - agent_service
     environment:
-      - AGENT_URL=http://agent_service
+      - AGENT_URL=http://agent_service:8080
     develop:
       watch:
         - path: src/client/

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -25,7 +25,7 @@ class AgentClient:
 
     def __init__(
         self,
-        base_url: str = "http://localhost",
+        base_url: str = "http://0.0.0.0",
         agent: str = None,
         timeout: float | None = None,
         get_info: bool = True,

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
     MODE: str | None = None
 
     HOST: str = "0.0.0.0"
-    PORT: int = 80
+    PORT: int = 8080
 
     AUTH_SECRET: SecretStr | None = None
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -56,13 +56,13 @@ async def main() -> None:
         agent_url = os.getenv("AGENT_URL")
         if not agent_url:
             host = os.getenv("HOST", "0.0.0.0")
-            port = os.getenv("PORT", 80)
+            port = os.getenv("PORT", 8080)
             agent_url = f"http://{host}:{port}"
         try:
             with st.spinner("Connecting to agent service..."):
                 st.session_state.agent_client = AgentClient(base_url=agent_url)
         except AgentClientError as e:
-            st.error(f"Error connecting to agent service: {e}")
+            st.error(f"Error connecting to agent service at {agent_url}: {e}")
             st.markdown("The service might be booting up. Try again in a few seconds.")
             st.stop()
     agent_client: AgentClient = st.session_state.agent_client

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -14,7 +14,7 @@ def test_init(mock_env):
     """Test client initialization with different parameters."""
     # Test default values
     client = AgentClient(get_info=False)
-    assert client.base_url == "http://localhost"
+    assert client.base_url == "http://0.0.0.0"
     assert client.timeout is None
 
     # Test custom values

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -23,7 +23,7 @@ def test_check_str_is_http():
 def test_settings_default_values():
     settings = Settings(_env_file=None)
     assert settings.HOST == "0.0.0.0"
-    assert settings.PORT == 80
+    assert settings.PORT == 8080
     assert settings.USE_AWS_BEDROCK is False
     assert settings.USE_FAKE_MODEL is False
 
@@ -72,8 +72,8 @@ def test_settings_with_multiple_api_keys():
 
 
 def test_settings_base_url():
-    settings = Settings(HOST="localhost", PORT=8000, _env_file=None)
-    assert settings.BASE_URL == "http://localhost:8000"
+    settings = Settings(HOST="0.0.0.0", PORT=8000, _env_file=None)
+    assert settings.BASE_URL == "http://0.0.0.0:8000"
 
 
 def test_settings_is_dev():

--- a/tests/integration/test_docker_e2e.py
+++ b/tests/integration/test_docker_e2e.py
@@ -10,7 +10,7 @@ def test_service_with_fake_model():
 
     This test requires the service container to be running with USE_FAKE_MODEL=true
     """
-    client = AgentClient("http://localhost", agent="chatbot")
+    client = AgentClient("http://0.0.0.0", agent="chatbot")
     response = client.invoke("Tell me a joke?", model="fake")
     assert response.type == "ai"
     assert response.content == "This is a test response from the fake model."

--- a/tests/service/conftest.py
+++ b/tests/service/conftest.py
@@ -38,12 +38,12 @@ def mock_httpx():
 
         def mock_stream(method: str, url: str, **kwargs):
             # Strip the base URL since TestClient expects just the path
-            path = url.replace("http://localhost", "")
+            path = url.replace("http://0.0.0.0", "")
             return client.stream(method, path, **kwargs)
 
         def mock_get(url: str, **kwargs):
             # Strip the base URL since TestClient expects just the path
-            path = url.replace("http://localhost", "")
+            path = url.replace("http://0.0.0.0", "")
             return client.get(path, **kwargs)
 
         with patch("httpx.stream", mock_stream):


### PR DESCRIPTION
Users reported various compatibility issues with running and accessing the service on `http://localhost:80` by default. Hopefully address those by switching to `0.0.0.0:8080` by default.