### PR TITLE
Add a agent for human in the loop

### DIFF
--- a/src/agents/agents.py
+++ b/src/agents/agents.py
@@ -5,6 +5,7 @@ from langgraph.graph.state import CompiledStateGraph
 from agents.bg_task_agent.bg_task_agent import bg_task_agent
 from agents.chatbot import chatbot
 from agents.command_agent import command_agent
+from agents.hitl_agent import hitl_agent
 from agents.research_assistant import research_assistant
 from schema import AgentInfo
 
@@ -24,6 +25,7 @@ agents: dict[str, Agent] = {
     ),
     "command-agent": Agent(description="A command agent.", graph=command_agent),
     "bg-task-agent": Agent(description="A background task agent.", graph=bg_task_agent),
+    "hitl_agent": Agent(description="A human-in-the-loop agent", graph=hitl_agent),
 }
 
 

--- a/src/agents/hitl_agent.py
+++ b/src/agents/hitl_agent.py
@@ -1,0 +1,84 @@
+from typing import Annotated, Literal
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import (
+    RunnableConfig,
+)
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import MessagesState, StateGraph
+
+
+class AgentState(MessagesState, total=False):
+    """`total=False` is PEP589 specs.
+
+    documentation: https://typing.readthedocs.io/en/latest/spec/typeddict.html#totality
+    """
+
+    status: Annotated[Literal["approve", "reject"], "Status must be either 'approve' or 'reject'"]
+
+
+def question(state: AgentState, config: RunnableConfig) -> AgentState:
+    return {
+        "messages": [
+            AIMessage(
+                content='question Node> Please enter "approve" or "reject."',
+            )
+        ]
+    }
+
+
+def human_input(state: AgentState, config: RunnableConfig) -> AgentState:
+    pass
+
+
+def show_status(state: AgentState, config: RunnableConfig) -> AgentState:
+    status = "reject"
+
+    latest_message = state["messages"][-1]
+    if latest_message.content == "approve":
+        status = "approve"
+
+    return {
+        "messages": [
+            AIMessage(
+                content=f'show_status Node> status is "{status}"',
+            )
+        ],
+        "status": status,
+    }
+
+
+def finish_message(state: AgentState, config: RunnableConfig) -> AgentState:
+    return {
+        "messages": [
+            AIMessage(
+                content="finish_message Node> see you",
+            )
+        ]
+    }
+
+
+def check_status(state: AgentState, config: RunnableConfig) -> AgentState:
+    if state.get("status") == "approve":
+        return "approve"
+
+    return "reject"
+
+
+# Define the graph
+agent = StateGraph(AgentState)
+agent.add_node("question", question)
+agent.add_node("human_input", human_input)
+agent.add_node("show_status", show_status)
+agent.add_node("finish_message", finish_message)
+
+agent.set_entry_point("question")
+
+agent.add_edge("question", "human_input")
+agent.add_edge("human_input", "show_status")
+agent.add_conditional_edges(
+    "show_status", check_status, {"approve": "finish_message", "reject": "question"}
+)
+agent.set_finish_point("finish_message")
+
+hitl_agent = agent.compile(checkpointer=MemorySaver(), interrupt_before=["human_input"])


### PR DESCRIPTION
This pull request introduces a new human-in-the-loop (HITL) agent and integrates it into the existing service. The most important changes include adding the HITL agent to the agents module, defining its state and behavior, and updating the service to handle HITL interactions. Additionally, tests have been updated to cover the new functionality.

Graph diagram of the added agent
![image](https://github.com/user-attachments/assets/fef4b7cc-2fbe-4e14-afe7-65be0aa8dca3)

Integration of HITL agent:

* [`src/agents/agents.py`](diffhunk://#diff-a00b719320be0c4a826168540f1857e65224f97e43936a68473be8ef51d1f2abR8): Added import for `hitl_agent` and included it in the `Agent` class. [[1]](diffhunk://#diff-a00b719320be0c4a826168540f1857e65224f97e43936a68473be8ef51d1f2abR8) [[2]](diffhunk://#diff-a00b719320be0c4a826168540f1857e65224f97e43936a68473be8ef51d1f2abR28)
* [`src/agents/hitl_agent.py`](diffhunk://#diff-9f4c6d9540ed48a0ef437aa36a733edac704f37a9322b2e42b94a4dcf96950a6R1-R84): Defined the HITL agent's state, nodes, and transitions, and compiled the agent with a memory saver checkpoint.

Service updates for HITL:

* [`src/service/service.py`](diffhunk://#diff-b678273f64e8e9df8f3a41b23f9fba9ca9e4809b93b53843fb1c370a86e69110L89-R117): Modified `_parse_input`, `invoke`, and `message_generator` functions to handle HITL interactions, including resuming from interruptions. [[1]](diffhunk://#diff-b678273f64e8e9df8f3a41b23f9fba9ca9e4809b93b53843fb1c370a86e69110L89-R117) [[2]](diffhunk://#diff-b678273f64e8e9df8f3a41b23f9fba9ca9e4809b93b53843fb1c370a86e69110L124-R133) [[3]](diffhunk://#diff-b678273f64e8e9df8f3a41b23f9fba9ca9e4809b93b53843fb1c370a86e69110L144-R153) [[4]](diffhunk://#diff-b678273f64e8e9df8f3a41b23f9fba9ca9e4809b93b53843fb1c370a86e69110L159-R174)

Test updates:

* [`tests/service/test_service.py`](diffhunk://#diff-47eca16cf491d705ba39595878c180ff16364aa01f6559017d0cb59c8b9b0474R9): Added imports for `Command` and updated tests to mock agent state and verify HITL behavior. [[1]](diffhunk://#diff-47eca16cf491d705ba39595878c180ff16364aa01f6559017d0cb59c8b9b0474R9) [[2]](diffhunk://#diff-47eca16cf491d705ba39595878c180ff16364aa01f6559017d0cb59c8b9b0474R21-R31) [[3]](diffhunk://#diff-47eca16cf491d705ba39595878c180ff16364aa01f6559017d0cb59c8b9b0474R44-R76) [[4]](diffhunk://#diff-47eca16cf491d705ba39595878c180ff16364aa01f6559017d0cb59c8b9b0474R91-R101)