### PR TITLE
Bugfix for empty updates, error handling, sidebar cleanup

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -187,7 +187,8 @@ class AgentClient:
                     # Yield the str token directly
                     return parsed["content"]
                 case "error":
-                    raise Exception(parsed["content"])
+                    error_msg = "Error: " + parsed["content"]
+                    return ChatMessage(type="ai", content=error_msg)
         return None
 
     def stream(

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -85,14 +85,15 @@ async def main() -> None:
     with st.sidebar:
         st.header(f"{APP_ICON} {APP_TITLE}")
 
-        # New Chat button at the top of the sidebar
-        if st.button("💬 New Chat", use_container_width=True):
+        ""
+        "Full toolkit for running an AI agent service built with LangGraph, FastAPI and Streamlit"
+        ""
+
+        if st.button(":material/chat: New Chat", use_container_width=True):
             st.session_state.messages = []
             st.session_state.thread_id = str(uuid.uuid4())
             st.rerun()
 
-        ""
-        "Full toolkit for running an AI agent service built with LangGraph, FastAPI and Streamlit"
         with st.popover(":material/settings: Settings", use_container_width=True):
             model_idx = agent_client.info.models.index(agent_client.info.default_model)
             model = st.selectbox("LLM to use", options=agent_client.info.models, index=model_idx)


### PR DESCRIPTION
Few small fixes

- handle service error case where node updates are empty during streaming (#198)
- Client returns an error chat message when streaming errors instead of stack trace
- Clean up sidebar new chat button