### PR TITLE
Reassemble partial `AIMessage` fragments from streamed tuples

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -241,14 +241,6 @@ async def message_generator(
                 processed_messages.append(_create_ai_message(current_message))
 
             for message in processed_messages:
-                logger.info(
-                    "\n====== STREAM EVENT ======\n"
-                    "type: %s\n"
-                    "repr: %r\n"
-                    "==========================",
-                    type(message),
-                    message,
-                )
                 try:
                     chat_message = langchain_to_chat_message(message)
                     chat_message.run_id = str(run_id)

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -222,6 +222,17 @@ async def message_generator(
                 new_messages = [event]
 
             for message in new_messages:
+                # Reassemble partial tuples
+                if isinstance(message, tuple):
+                    key, value = message
+                    if key == "content":
+                        message = AIMessage(content=value)
+                    elif key == "tool_calls":
+                        # Empty content + list of tool calls
+                        message = AIMessage(content="", tool_calls=value)
+                    else:
+                        # Service metadata - skip it
+                        continue
                 try:
                     chat_message = langchain_to_chat_message(message)
                     chat_message.run_id = str(run_id)

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -227,7 +227,7 @@ async def message_generator(
             # We accumulate only supported fields into `parts` and skip unsupported metadata.
             # More info at: https://langchain-ai.github.io/langgraph/cloud/how-tos/stream_messages/
             processed_messages = []
-            current_message = {}
+            current_message: dict[str, Any] = {}
             for message in new_messages:
                 if isinstance(message, tuple):
                     key, value = message

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -226,10 +226,20 @@ async def message_generator(
                 if isinstance(message, tuple):
                     key, value = message
                     if key == "content":
-                        message = AIMessage(content=value)
+                        # Create an AIMessage with the minimum required fields
+                        message = AIMessage(
+                            content=value,
+                            id=str(uuid4()),  # Generate a new ID if missing
+                            response_metadata={},  # Empty metadata by default
+                        )
+                    # Empty content + list of tool calls
                     elif key == "tool_calls":
-                        # Empty content + list of tool calls
-                        message = AIMessage(content="", tool_calls=value)
+                        message = AIMessage(
+                            content="",
+                            tool_calls=value,
+                            id=str(uuid4()),
+                            response_metadata={},
+                        )
                     else:
                         # Service metadata - skip it
                         continue

--- a/tests/service/test_service_streaming.py
+++ b/tests/service/test_service_streaming.py
@@ -1,0 +1,58 @@
+import pytest
+from langchain_core.messages import AIMessage
+
+from service.service import _create_ai_message
+
+
+@pytest.mark.parametrize(
+    "parts, expected",
+    [
+        # 1) Basic content + tool_calls
+        (
+            {"content": "Hello", "tool_calls": []},
+            {"content": "Hello", "tool_calls": []},
+        ),
+        # 2) Unknown keys are ignored
+        (
+            {"content": "Test", "foobar": 123, "tool_calls": []},
+            {"content": "Test", "tool_calls": []},
+        ),
+        # 3) Extra valid AIMessage params (id, type) pass through
+        (
+            {
+                "content": "Hey",
+                "id": "abc-123",
+                "type": "ai",
+                "tool_calls": [],
+            },
+            {"content": "Hey", "id": "abc-123", "type": "ai", "tool_calls": []},
+        ),
+    ],
+)
+def test_create_ai_message_filters_and_passes_through(parts, expected):
+    """
+    _create_ai_message should:
+      - Drop unknown keys ("foobar")
+      - Preserve keys that match AIMessage signature
+      - Use the final value for duplicate keys in the parts dict
+    """
+    msg: AIMessage = _create_ai_message(parts)
+    for key, val in expected.items():
+        assert getattr(msg, key) == val
+
+
+def test_create_ai_message_missing_required_content_raises():
+    """
+    AIMessage requires 'content'; if missing, _create_ai_message should
+    bubble up the TypeError from the constructor.
+    """
+    with pytest.raises(TypeError):
+        _create_ai_message({"tool_calls": []})
+
+
+def test_create_ai_message_empty_dict_raises():
+    """
+    Completely empty parts should also fail to construct an AIMessage.
+    """
+    with pytest.raises(TypeError):
+        _create_ai_message({})


### PR DESCRIPTION
I've observed that the model's final response sometimes arrives in multiple fragments instead of a single complete message. This behavior complicates downstream processing, as the system expects a fully assembled message.

Here’s an example of the issue observed in the logs:

<details>

<summary>Log</summary>

```commandLine
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('content', "HERE'S THE LONG CONTENT")
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('content',
2025-04-29 10:54:30  'HERE'S THE LONG CONTENT'
2025-04-29 10:54:30  '\n'
2025-04-29 10:54:30  '...')
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('additional_kwargs', {})
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('additional_kwargs', {})
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('response_metadata', {'finish_reason': 'stop', 'model_name': 'gpt-4.1-2025-04-14', 'system_fingerprint': 'fp_a1102cf978'})
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('response_metadata',
2025-04-29 10:54:30  {'finish_reason': 'stop', 'model_name': 'gpt-4.1-2025-04-14', 'system_fingerprint': 'fp_a1102cf978'})
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('type', 'ai')
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('type', 'ai')
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('name', None)
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('name', None)
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('id', 'run-79a8baa2-891f-4621-bc7d-08749d308260')
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('id', 'run-79a8baa2-891f-4621-bc7d-08749d308260')
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('example', False)
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('example', False)
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('tool_calls', [])
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('tool_calls', [])
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('invalid_tool_calls', [])
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('invalid_tool_calls', [])
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
2025-04-29 10:54:30 type: <class 'tuple'>
2025-04-29 10:54:30 repr: ('usage_metadata', None)
2025-04-29 10:54:30 pprint:
2025-04-29 10:54:30 ('usage_metadata', None)
2025-04-29 10:54:30 ==========================
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [ERROR] [/app/service/service.py:238] Error parsing message: Unsupported message type: tuple
2025-04-29 10:54:30 [2025-04-29 07:54:30 +0000] [1] [INFO] [/app/service/service.py:224] 
2025-04-29 10:54:30 ====== STREAM EVENT ======
```

</details>

To address this, this PR adds logic to correctly reassemble incoming fragmented tuples into a proper `AIMessage`. If the tuple represents a `content` or `tool_calls` field, we now construct an `AIMessage` accordingly; otherwise, metadata tuples are skipped.