### PR TITLE
Bump llama-guard to 4-12B

### DIFF
--- a/src/agents/llama_guard.py
+++ b/src/agents/llama_guard.py
@@ -81,7 +81,7 @@ class LlamaGuard:
             print("GROQ_API_KEY not set, skipping LlamaGuard")
             self.model = None
             return
-        self.model = get_model(GroqModelName.LLAMA_GUARD_3_8B).with_config(tags=["skip_stream"])
+        self.model = get_model(GroqModelName.LLAMA_GUARD_4_12B).with_config(tags=["skip_stream"])
         self.prompt = PromptTemplate.from_template(llama_guard_instructions)
 
     def _compile_prompt(self, role: str, messages: list[AnyMessage]) -> str:

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -47,7 +47,7 @@ _MODEL_TABLE = {
     VertexAIModelName.GEMINI_25_PRO_EXP: "gemini-2.5-pro-exp-03-25",
     GroqModelName.LLAMA_31_8B: "llama-3.1-8b-instant",
     GroqModelName.LLAMA_33_70B: "llama-3.3-70b-versatile",
-    GroqModelName.LLAMA_GUARD_3_8B: "llama-guard-3-8b",
+    GroqModelName.LLAMA_GUARD_4_12B: "meta-llama/llama-guard-4-12b",
     AWSModelName.BEDROCK_HAIKU: "anthropic.claude-3-5-haiku-20241022-v1:0",
     AWSModelName.BEDROCK_SONNET: "anthropic.claude-3-5-sonnet-20240620-v1:0",
     OllamaModelName.OLLAMA_GENERIC: "ollama",
@@ -125,7 +125,7 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
     if model_name in VertexAIModelName:
         return ChatVertexAI(model=api_model_name, temperature=0.5, streaming=True)
     if model_name in GroqModelName:
-        if model_name == GroqModelName.LLAMA_GUARD_3_8B:
+        if model_name == GroqModelName.LLAMA_GUARD_4_12B:
             return ChatGroq(model=api_model_name, temperature=0.0)
         return ChatGroq(model=api_model_name, temperature=0.5)
     if model_name in AWSModelName:

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -67,7 +67,7 @@ class GroqModelName(StrEnum):
     LLAMA_31_8B = "groq-llama-3.1-8b"
     LLAMA_33_70B = "groq-llama-3.3-70b"
 
-    LLAMA_GUARD_3_8B = "groq-llama-guard-3-8b"
+    LLAMA_GUARD_4_12B = "meta-llama/llama-guard-4-12B"
 
 
 class AWSModelName(StrEnum):

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -46,9 +46,9 @@ def test_get_model_groq():
 
 def test_get_model_groq_guard():
     with patch.dict(os.environ, {"GROQ_API_KEY": "test_key"}):
-        model = get_model(GroqModelName.LLAMA_GUARD_3_8B)
+        model = get_model(GroqModelName.LLAMA_GUARD_4_12B)
         assert isinstance(model, ChatGroq)
-        assert model.model_name == "llama-guard-3-8b"
+        assert model.model_name == "meta-llama/llama-guard-4-12b"
         assert model.temperature < 0.01
 
 


### PR DESCRIPTION
Groq is deprecating Llama-Guard-3 in June so migrating to the latest