### PR TITLE
Correct a 'uv sync' issue on Windows introduced with the Chroma dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "numexpr ~=2.10.1",
     "numpy ~=1.26.4; python_version <= '3.12'",
     "numpy ~=2.2.3; python_version >= '3.13'",
+    "onnxruntime ~= 1.21.1",
     "pandas ~=2.2.3",
     "psycopg[binary,pool] ~=3.2.4",
     "pyarrow >=18.1.0",


### PR DESCRIPTION
The May 10, 2025 release introduced an issue on Windows.  It appears langchain-chroma ~=0.2.3 caused the following error when running `uv sync --frozen`

```
Resolved 217 packages in 217ms
error: Distribution `onnxruntime==1.22.0 @ registry+https://pypi.org/simple` can't be installed because it 
doesn't have a source distribution or wheel for the current platform

hint: You're on Windows (`win_amd64`), but `onnxruntime` (v1.22.0) only has wheels for the following 
platforms: `manylinux_2_27_aarch64`, `manylinux_2_27_x86_64`, `manylinux_2_28_aarch64`, 
`manylinux_2_28_x86_64`, `macosx_13_0_universal2`
```
After a little testing, it appears setting the version in the pyproject.toml for "onnxruntime ~= 1.21.1" cleared up the issue.  

An issue for this problem was created a few days ago:  [Windows wheels are not published on pypi for version 1.22](https://github.com/microsoft/onnxruntime/issues/24714)



