### PR TITLE
Fix incorrect model name for 2.5 Flash

### DIFF
--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -58,7 +58,7 @@ class VertexAIModelName(StrEnum):
 
     GEMINI_15_PRO = "gemini-1.5-pro-002"
     GEMINI_20_FLASH = "gemini-2.0-flash"
-    GEMINI_25_FLASH_THINKING = "gemini-2.5-flash-preview-04-17"
+    GEMINI_25_FLASH_THINKING = "models/gemini-2.5-flash-preview-04-17"
     GEMINI_25_PRO = "gemini-2.5-pro-preview-05-06"
     GEMINI_25_PRO_EXP = "gemini-2.5-pro-exp-03-25"
 


### PR DESCRIPTION
After retesting, it was discovered that the model name used for 2.5 Flash was incorrect. This update corrects the model name to ensure proper identification and functionality.