### PR TITLE
Postgres Checkpointer and Memory Needs More Resilient Database Connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ POSTGRES_PORT=
 POSTGRES_DB=
 
 # you will be able to identify AST connections in Postgres Connection Manager under this Application Name
-POSTGRES_APPLICATION_NAME = "agent-service-toolkit"
+# POSTGRES_APPLICATION_NAME = "agent-service-toolkit"
 # set these values to customize the number of connections in the pool. Saver and store have independent connection pools
 # POSTGRES_MIN_CONNECTIONS_PER_POOL=1
 # POSTGRES_MAX_CONNECTIONS_PER_POOL= 3

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,12 @@ POSTGRES_HOST=
 POSTGRES_PORT=
 POSTGRES_DB=
 
+# you will be able to identify AST connections in Postgres Connection Manager under this Application Name
+POSTGRES_APPLICATION_NAME = "agent-service-toolkit"
+# set these values to customize the number of connections in the pool. Saver and store have independent connection pools
+# POSTGRES_MIN_CONNECTIONS_PER_POOL=1
+# POSTGRES_MAX_CONNECTIONS_PER_POOL= 3
+
 # OpenWeatherMap API key
 OPENWEATHERMAP_API_KEY=
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -104,6 +104,9 @@ class Settings(BaseSettings):
     POSTGRES_HOST: str | None = None
     POSTGRES_PORT: int | None = None
     POSTGRES_DB: str | None = None
+    POSTGRES_APPLICATION_NAME: str = "agent-service-toolkit"
+    POSTGRES_MIN_CONNECTIONS_PER_POOL: int = 1
+    POSTGRES_MAX_CONNECTIONS_PER_POOL: int = 1
 
     # MongoDB Configuration
     MONGO_HOST: str | None = None

--- a/src/memory/postgres.py
+++ b/src/memory/postgres.py
@@ -1,8 +1,10 @@
 import logging
-from contextlib import AbstractAsyncContextManager
+from contextlib import asynccontextmanager
 
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.postgres import AsyncPostgresStore
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
 
 from core.settings import settings
 
@@ -29,6 +31,11 @@ def validate_postgres_config() -> None:
             "These environment variables must be set to use PostgreSQL persistence."
         )
 
+    if settings.POSTGRES_MIN_CONNECTIONS_PER_POOL > settings.POSTGRES_MAX_CONNECTIONS_PER_POOL:
+        raise ValueError(
+            f"POSTGRES_MIN_CONNECTIONS_PER_POOL ({settings.POSTGRES_MIN_CONNECTIONS_PER_POOL}) must be less than or equal to POSTGRES_MAX_CONNECTIONS_PER_POOL ({settings.POSTGRES_MAX_CONNECTIONS_PER_POOL})"
+        )
+
 
 def get_postgres_connection_string() -> str:
     """Build and return the PostgreSQL connection string from settings."""
@@ -42,23 +49,54 @@ def get_postgres_connection_string() -> str:
     )
 
 
-def get_postgres_saver() -> AbstractAsyncContextManager[AsyncPostgresSaver]:
-    """Initialize and return a PostgreSQL saver instance."""
+@asynccontextmanager
+async def get_postgres_saver():
+    """Initialize and return a PostgreSQL saver instance based on a connection pool for more resilent connections."""
     validate_postgres_config()
-    return AsyncPostgresSaver.from_conn_string(get_postgres_connection_string())
+    application_name = settings.POSTGRES_APPLICATION_NAME + "-" + "saver"
+
+    async with AsyncConnectionPool(
+        get_postgres_connection_string(),
+        min_size=settings.POSTGRES_MIN_CONNECTIONS_PER_POOL,
+        max_size=settings.POSTGRES_MAX_CONNECTIONS_PER_POOL,
+        # Langgraph requires autocommmit=true and row_factory to be set to dict_row.
+        # Application_name is passed so you can identify the connection in your Postgres database connection manager.
+        kwargs={"autocommit": True, "row_factory": dict_row, "application_name": application_name},
+        # makes sure that the connection is still valid before using it
+        check=AsyncConnectionPool.check_connection,
+    ) as pool:
+        try:
+            checkpointer = AsyncPostgresSaver(pool)
+            await checkpointer.setup()
+            yield checkpointer
+        finally:
+            await pool.close()
 
 
-def get_postgres_store():
+@asynccontextmanager
+async def get_postgres_store():
     """
-    Get a PostgreSQL store instance.
+    Get a PostgreSQL store instance based on a connection pool for more resilent connections.
 
-    Returns an AsyncPostgresStore instance that needs to be used with async context manager
-    pattern according to the documentation:
+    Returns an AsyncPostgresStore instance that can be used with async context manager pattern.
 
-    async with AsyncPostgresStore.from_conn_string(conn_string) as store:
-        await store.setup()  # Run migrations
-        # Use store...
     """
     validate_postgres_config()
-    connection_string = get_postgres_connection_string()
-    return AsyncPostgresStore.from_conn_string(connection_string)
+    application_name = settings.POSTGRES_APPLICATION_NAME + "-" + "store"
+
+    async with AsyncConnectionPool(
+        get_postgres_connection_string(),
+        min_size=settings.POSTGRES_MIN_CONNECTIONS_PER_POOL,
+        max_size=settings.POSTGRES_MAX_CONNECTIONS_PER_POOL,
+        # Langgraph requires autocommmit=true and row_factory to be set to dict_row
+        # Application_name is passed so you can identify the connection in your Postgres database connection manager.
+        kwargs={"autocommit": True, "row_factory": dict_row, "application_name": application_name},
+        # makes sure that the connection is still valid before using it
+        check=AsyncConnectionPool.check_connection,
+    ) as pool:
+        try:
+            store = AsyncPostgresStore(pool)
+            await store.setup()
+            yield store
+        finally:
+            await pool.close()


### PR DESCRIPTION
When using Postgres as your checkpointer and memory store, AST connects to Postgres at startup time. If those connections are ever closed (timeout, network interruption, postgres restart), the toolkit does not attempt to reconnect. Your easiest recourse is to restart the toolkit.

LangGraph’s Postgres Checkpointer added support for connection pools in [Release checkpointpostgres==1.0.4 · langchain-ai/langgraph](https://github.com/langchain-ai/langgraph/releases/tag/checkpointpostgres%3D%3D1.0.4)

This PR changes AST Postgres memory to use connection pools so that connection management will be abstracted away.

The number of connections is configurable based on `POSTGRES_MIN_CONNECTIONS_PER_POOL` and `POSTGRES_MAX_CONNECTIONS_PER_POOL` environment variables. Default is 1 connection so that existing toolkit users aren't caught off guard by a connection count increase.  You can adjust these as you see fit in various environments based on load.

The default check function ([link to documentation](https://www.psycopg.org/psycopg3/docs/api/pool.html#psycopg_pool.AsyncConnectionPool.check_connection)) ensures that connections are discarded and replaced, if needed, before being used.

**Implementation was based on these links:**
- LangGraph Checkpoint Postgres Usage Instructions ([link to documentation](https://github.com/langchain-ai/langgraph/blob/d64447c4c22d5358fef8d29a82fd6a23e83cda0e/libs/checkpoint-postgres/README.md))
- LangGraph Test Suite Test for Pool-based Postgres Checkpointer ([link to code](https://github.com/langchain-ai/langgraph/blob/d64447c4c22d5358fef8d29a82fd6a23e83cda0e/libs/checkpoint-postgres/tests/test_async.py#L33C1-L56C60))

This PR also uses a new `POSTGRES_APPLICATION_NAME` environment variable ( default: agent-service-toolkit) to prefix the Application Name used in the Postgres Connection to make it easier for you to identify AST connections in your Postgres tooling.


Closes #212 
