### PR TITLE
feature: Separate dialog history of each agent

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -100,13 +100,15 @@ async def info() -> ServiceMetadata:
     )
 
 
-async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[str, Any], UUID]:
+async def _handle_input(
+    user_input: UserInput, agent: AgentGraph, agent_id: str
+) -> tuple[dict[str, Any], UUID]:
     """
     Parse user input and handle any required interrupt resumption.
     Returns kwargs for agent invocation and the run_id.
     """
     run_id = uuid4()
-    thread_id = user_input.thread_id or str(uuid4())
+    thread_id = f"{user_input.thread_id or str(uuid4())}-{agent_id}"
     user_id = user_input.user_id or str(uuid4())
 
     configurable = {"thread_id": thread_id, "model": user_input.model, "user_id": user_id}
@@ -170,7 +172,7 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
     # you'd want to include it. You could update the API to return a list of ChatMessages
     # in that case.
     agent: AgentGraph = get_agent(agent_id)
-    kwargs, run_id = await _handle_input(user_input, agent)
+    kwargs, run_id = await _handle_input(user_input, agent, agent_id)
 
     try:
         response_events: list[tuple[str, Any]] = await agent.ainvoke(**kwargs, stream_mode=["updates", "values"])  # type: ignore # fmt: skip
@@ -203,7 +205,7 @@ async def message_generator(
     This is the workhorse method for the /stream endpoint.
     """
     agent: AgentGraph = get_agent(agent_id)
-    kwargs, run_id = await _handle_input(user_input, agent)
+    kwargs, run_id = await _handle_input(user_input, agent, agent_id)
 
     try:
         # Process streamed events from the graph and yield messages over the SSE stream.


### PR DESCRIPTION
This PR separate dialog history of multiple agents.
- As-is) Talking to multiple agents using a single user ID leads to mixed dialog history.
- To-be) Service adds agent ID to thread ID to separate dialog histories in `_handle_input`.
- Related to: https://github.com/JoshuaC215/agent-service-toolkit/issues/188