### PR TITLE
Fix Claude streaming generator error with empty tokens

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -310,7 +310,9 @@ class AgentClient:
                             parsed = self._parse_stream_line(line)
                             if parsed is None:
                                 break
-                            yield parsed
+                            # Don't yield empty string tokens as they cause generator issues
+                            if parsed != "":
+                                yield parsed
             except httpx.HTTPError as e:
                 raise AgentClientError(f"Error: {e}")
 


### PR DESCRIPTION
Fixes RuntimeError: 'generator didn't stop after athrow()' that occurs when Claude sends empty string tokens before tool calls in streaming mode.

The issue was that empty string tokens ('') were being yielded to the async generator, causing it to crash when Streamlit tried to process them.

Solution: Skip yielding empty string tokens while preserving all other content and tool execution functionality.

This enables Claude models to properly execute tool calls in streaming mode.