### PR TITLE
Use the default model configured in the service if one isn't passed in the request

### DIFF
--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -46,8 +46,8 @@ class UserInput(BaseModel):
     )
     model: SerializeAsAny[AllModelEnum] | None = Field(
         title="Model",
-        description="LLM Model to use for the agent.",
-        default=OpenAIModelName.GPT_4O_MINI,
+        description="LLM Model to use for the agent. Defaults to the default model set in the settings of the service.",
+        default=None,
         examples=[OpenAIModelName.GPT_4O_MINI, AnthropicModelName.HAIKU_35],
     )
     thread_id: str | None = Field(

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -109,7 +109,9 @@ async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[
     thread_id = user_input.thread_id or str(uuid4())
     user_id = user_input.user_id or str(uuid4())
 
-    configurable = {"thread_id": thread_id, "model": user_input.model, "user_id": user_id}
+    configurable = {"thread_id": thread_id, "user_id": user_id}
+    if user_input.model is not None:
+        configurable["model"] = user_input.model
 
     callbacks = []
     if settings.LANGFUSE_TRACING:
@@ -119,7 +121,9 @@ async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[
         callbacks.append(langfuse_handler)
 
     if user_input.agent_config:
-        if overlap := configurable.keys() & user_input.agent_config.keys():
+        # Check for reserved keys (including 'model' even if not in configurable)
+        reserved_keys = {"thread_id", "user_id", "model"}
+        if overlap := reserved_keys & user_input.agent_config.keys():
             raise HTTPException(
                 status_code=422,
                 detail=f"agent_config contains reserved keys: {overlap}",


### PR DESCRIPTION
Prior to this, if you make a request directly to the service, and don't specify a model, it's hardcoded to gpt-4o-mini, even if there's a different default model configured in the service. This makes it more consistent (IMO) by using the setting for the default model