### PR TITLE
Make the history endpoint async

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -372,14 +372,14 @@ async def feedback(feedback: Feedback) -> FeedbackResponse:
 
 
 @router.post("/history")
-def history(input: ChatHistoryInput) -> ChatHistory:
+async def history(input: ChatHistoryInput) -> ChatHistory:
     """
     Get chat history.
     """
     # TODO: Hard-coding DEFAULT_AGENT here is wonky
     agent: AgentGraph = get_agent(DEFAULT_AGENT)
     try:
-        state_snapshot = agent.get_state(
+        state_snapshot = await agent.aget_state(
             config=RunnableConfig(configurable={"thread_id": input.thread_id})
         )
         messages: list[AnyMessage] = state_snapshot.values["messages"]

--- a/tests/service/test_service.py
+++ b/tests/service/test_service.py
@@ -170,7 +170,7 @@ def test_history(test_client, mock_agent) -> None:
     ANSWER = "The weather in Tokyo is 70 degrees."
     user_question = HumanMessage(content=QUESTION)
     agent_response = AIMessage(content=ANSWER)
-    mock_agent.get_state.return_value = StateSnapshot(
+    mock_agent.aget_state.return_value = StateSnapshot(
         values={"messages": [user_question, agent_response]},
         next=(),
         config={},


### PR DESCRIPTION
Pretty self explanatory, but especially when running with just 1 uvicorn worker, this can be fairly important. Also aligns with all the other async endpoints