### PR TITLE
Add a setting for log level, and graceful shutdown timeout

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -37,6 +37,27 @@ class DatabaseType(StrEnum):
     MONGO = "mongo"
 
 
+class LogLevel(StrEnum):
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+    def to_logging_level(self) -> int:
+        """Convert to Python logging level constant."""
+        import logging
+
+        mapping = {
+            LogLevel.DEBUG: logging.DEBUG,
+            LogLevel.INFO: logging.INFO,
+            LogLevel.WARNING: logging.WARNING,
+            LogLevel.ERROR: logging.ERROR,
+            LogLevel.CRITICAL: logging.CRITICAL,
+        }
+        return mapping[self]
+
+
 def check_str_is_http(x: str) -> str:
     http_url_adapter = TypeAdapter(HttpUrl)
     return str(http_url_adapter.validate_python(x))
@@ -54,6 +75,8 @@ class Settings(BaseSettings):
 
     HOST: str = "0.0.0.0"
     PORT: int = 8080
+    GRACEFUL_SHUTDOWN_TIMEOUT: int = 30
+    LOG_LEVEL: LogLevel = LogLevel.WARNING
 
     AUTH_SECRET: SecretStr | None = None
 


### PR DESCRIPTION
Log level is fairly self explanatory, graceful shutdown timeout allows ongoing requests a period of time to complete after a `SIGTERM` - which is more important for longer running requests as these generally are, [especially when running in k8s](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)