### PR TITLE
Add generation function for improved operator ids in OpenAPI spec

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, status
 from fastapi.responses import StreamingResponse
+from fastapi.routing import APIRoute
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from langchain_core._api import LangChainBetaWarning
 from langchain_core.messages import AIMessage, AIMessageChunk, AnyMessage, HumanMessage, ToolMessage
@@ -39,6 +40,11 @@ from service.utils import (
 
 warnings.filterwarnings("ignore", category=LangChainBetaWarning)
 logger = logging.getLogger(__name__)
+
+
+def custom_generate_unique_id(route: APIRoute) -> str:
+    """Generate idiomatic operation IDs for OpenAPI client generation."""
+    return route.name
 
 
 def verify_bearer(
@@ -91,7 +97,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         raise
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, generate_unique_id_function=custom_generate_unique_id)
 router = APIRouter(dependencies=[Depends(verify_bearer)])
 
 


### PR DESCRIPTION
The OpenAPI spec automatically generated by FastAPI contains a unique operation ID for each route. However, the default way to generate these is `{python function name}{pathName}{method}`. This method generally does not lead to an idiomatic method name. For example, the health route will receive an operation ID of `health_check_health_get`. The problem when generating a client SDK from the OpenAPI spec is that the operation IDs are generally the same as the method name. Hence, FastAPI recommends changing them to something more idiomatic after your API is finalized [FastAPI Docs](https://fastapi.tiangolo.com/advanced/generate-clients/#custom-operation-ids-and-better-method-namesl).

This PR defines a simple generator function based on the recommended approach in the FastAPI docs that will result in idiomatic operation IDs based on the route names.