### PR TITLE
feat(skills): add plugin-style skill system for dynamic instruction l…

### DIFF
--- a/docs/Skill_System.md
+++ b/docs/Skill_System.md
@@ -1,0 +1,184 @@
+# Skill System
+
+The skill system is a plugin-style architecture — similar to GitHub Copilot / Cursor Rules / Claude AGENTS.md — that allows agents to dynamically discover, load, and execute specific instructions and scripts.
+
+---
+
+## 1. File Change Summary
+
+### New Files
+
+| Path | Description |
+|------|-------------|
+| `src/skills/__init__.py` | Module entry point, exports core components |
+| `src/skills/types.py` | Type definitions: `Skill`, `SkillMetadata`, `SkillContent`, `Resource` |
+| `src/skills/registry.py` | Skill registry with multi-directory scanning and hierarchical override |
+| `src/skills/loader.py` | Progressive loader, loads skill content on demand |
+| `src/skills/matcher.py` | Semantic matcher with keyword / path / semantic triggers |
+| `src/skills/resources.py` | Resource resolver and script executor |
+| `src/skills/toolkit.py` | 6 LangChain tools + `SkillSystem` facade class |
+| `src/skills/catalog/git_operations/` | Example skill (Git operations guide) |
+| `tests/skills/test_skill_system.py` | Unit tests |
+
+### Modified Files
+
+| Path | Description |
+|------|-------------|
+| `src/streamlit_app.py` | Sidebar: added "Skills" popover showing skill load status |
+
+---
+
+## 2. Core Architecture
+
+```
+Startup                             Runtime
+   │                                  │
+   ▼                                  ▼
+┌──────────────┐    query    ┌──────────────┐
+│ SkillRegistry│◄────────────│ SkillMatcher │
+│  (metadata)  │             │  (semantic)  │
+└──────┬───────┘             └──────────────┘
+       │                              │
+       ▼ load_content()               │
+┌──────────────┐                      │
+│ SkillLoader  │◄─────────────────────┘
+│  (lazy load) │
+└──────────────┘
+```
+
+### Hierarchical Override
+
+Priority from low to high:
+
+1. **Global skills**: `src/skills/catalog/`
+2. **Agent-specific**: `src/agents/{agent_name}/skills/`
+
+Skills scanned later override earlier ones with the same ID.
+
+---
+
+## 3. Skill Format (SKILL.md)
+
+```yaml
+---
+name: Skill Name
+description: What this skill does
+version: "1.0"
+triggers:
+  - type: semantic
+    keywords: ["keyword1", "keyword2"]
+  - type: path_glob
+    pattern: "**/*.py"
+  - type: always
+resources:
+  - scripts/check.py
+  - templates/doc.md
+---
+
+# Instruction content
+```
+
+---
+
+## 4. Agent Integration
+
+### Option 1: Inject all tools
+
+```python
+from skills import skill_tools
+
+agent = create_agent(
+    model=model,
+    tools=existing_tools + skill_tools,
+)
+```
+
+### Option 2: Select specific tools
+
+```python
+from skills.toolkit import list_available_skills, load_skill
+
+agent_tools = [list_available_skills, load_skill]
+```
+
+### Initialize the skill system
+
+```python
+from pathlib import Path
+from skills import init_skill_system
+
+# Call at service startup
+init_skill_system(
+    global_root=Path("src/skills/catalog"),
+    agent_root=Path("src/agents/my-agent/skills"),  # Optional
+)
+```
+
+---
+
+## 5. Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_available_skills` | List all available skills and their status |
+| `find_skills_for_task` | Find relevant skills based on a task description |
+| `load_skill` | Load the full content of a specific skill |
+| `get_skill_resource` | Read a resource file from a skill directory |
+| `list_skill_resources` | List all resources for a skill |
+| `run_skill_script` | Execute a script from a skill directory |
+
+---
+
+## 6. Future Roadmap
+
+### Short-term
+
+1. **Service startup integration**
+   Call `init_skill_system()` in `src/service/service.py`'s `lifespan` to auto-initialize skills at startup.
+
+2. **Add tools to specific agents**
+   Inject `skill_tools` into `research-assistant` or other agents so they can autonomously query and use skills.
+
+3. **Create more example skills**
+   - `code_review`: Code review best practices
+   - `testing`: Test writing guidelines
+   - `documentation`: Documentation standards
+
+### Medium-term
+
+1. **Enhanced semantic matching**
+   Integrate an embedding model (e.g. `sentence-transformers`) to make `find_skills_for_task` smarter.
+
+2. **Dynamic skill loading API**
+   Add REST API endpoints to register/unregister skills at runtime.
+
+### Long-term
+
+1. **Skill marketplace**
+   Support downloading and installing community skill packs from remote repositories.
+
+2. **Security sandbox**
+   Add Docker/subprocess sandboxing for `ScriptExecutor` to isolate script execution.
+
+---
+
+## 7. Design Principles (Industry References)
+
+### Convention over Configuration
+
+File names and locations are fixed (e.g. `AGENTS.md`, `.cursorrules`) — no explicit registration needed.
+The system auto-scans `catalog/` directories for `SKILL.md` files.
+
+### Hierarchical Override
+
+OpenAI Codex: `~/.codex/AGENTS.md` → `repo/.codex/AGENTS.md` → `cwd/AGENTS.md`, with closer directories taking higher priority.
+This implementation supports agent-specific skills in `src/agents/{agent_name}/skills/`.
+
+### Size Limits and Truncation
+
+Codex defaults to a 32KiB cap; this implementation (`MAX_CONTENT_SIZE = 32 * 1024`) matches that.
+
+### Agent Autonomy
+
+The industry trend is toward letting the LLM decide whether it needs a particular instruction, rather than pre-computing similarity.
+The `find_skills_for_task` tool lets the agent proactively query the skill catalog when needed.

--- a/src/skills/__init__.py
+++ b/src/skills/__init__.py
@@ -1,0 +1,30 @@
+"""Skill System
+
+Provides intelligent skill discovery, progressive loading, and semantic matching.
+"""
+
+from skills.loader import SkillLoader
+from skills.matcher import SkillMatcher
+from skills.registry import SkillRegistry
+from skills.resources import ResourceResolver, ScriptExecutor
+from skills.toolkit import SkillSystem, init_skill_system, skill_tools
+from skills.types import Resource, Skill, SkillContent, SkillMetadata, TriggerType
+
+__all__ = [
+    # Types
+    "Skill",
+    "SkillMetadata",
+    "SkillContent",
+    "Resource",
+    "TriggerType",
+    # Core
+    "SkillRegistry",
+    "SkillLoader",
+    "SkillMatcher",
+    "ResourceResolver",
+    "ScriptExecutor",
+    # Toolkit
+    "skill_tools",
+    "init_skill_system",
+    "SkillSystem",
+]

--- a/src/skills/catalog/git_operations/SKILL.md
+++ b/src/skills/catalog/git_operations/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: Git Operations
+description: Git version control best practices including commits, branches, and merges
+version: "1.0"
+triggers:
+  - type: semantic
+    keywords: ["git", "commit", "branch", "merge", "push", "pull", "rebase", "version control"]
+  - type: path_glob
+    pattern: "**/.git/**"
+resources:
+  - scripts/commit_check.py
+  - templates/commit_message.md
+dependencies: []
+---
+
+# Git Operations Guide
+
+## Commit Conventions
+
+Use Conventional Commits format:
+
+| Type | Description |
+|------|-------------|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `docs:` | Documentation update |
+| `refactor:` | Code refactoring |
+| `test:` | Test related |
+| `chore:` | Build/tooling related |
+
+### Example
+
+```
+feat(auth): add OAuth2 login support
+
+- Add Google OAuth2 provider
+- Add session management
+- Update user model with oauth fields
+
+Closes #123
+```
+
+## Branch Strategy
+
+- `main`: Production branch, accepts merges only
+- `develop`: Development branch
+- `feature/*`: Feature branches, created from develop
+- `hotfix/*`: Hotfix branches, created from main
+
+## Merge Workflow
+
+1. Ensure local branch is synced with remote: `git fetch origin`
+2. Run tests to confirm they pass
+3. Use `--no-ff` to preserve merge history: `git merge --no-ff feature/xxx`
+4. Delete the merged feature branch
+
+## Common Commands
+
+```bash
+# Check status
+git status
+
+# Stage changes
+git add -p  # Interactive staging
+
+# Commit
+git commit -v  # Show diff
+
+# Push
+git push origin HEAD
+
+# Rollback
+git reset --soft HEAD~1  # Soft reset, keep changes
+```

--- a/src/skills/catalog/git_operations/scripts/commit_check.py
+++ b/src/skills/catalog/git_operations/scripts/commit_check.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Check if the last commit message follows Conventional Commits format."""
+
+import re
+import subprocess
+import sys
+
+
+def get_last_commit_message() -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--pretty=%B"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def check_conventional_commit(message: str) -> bool:
+    pattern = r"^(feat|fix|docs|refactor|test|chore|style|perf|ci|build|revert)(\(.+\))?: .+"
+    return bool(re.match(pattern, message))
+
+
+def main() -> None:
+    message = get_last_commit_message()
+    if not message:
+        print("No commit message found.")
+        sys.exit(1)
+
+    if check_conventional_commit(message):
+        print(f"✓ Commit message follows Conventional Commits: {message}")
+    else:
+        print(f"✗ Commit message does not follow Conventional Commits: {message}")
+        print("  Expected format: type(scope): description")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/skills/catalog/git_operations/templates/commit_message.md
+++ b/src/skills/catalog/git_operations/templates/commit_message.md
@@ -1,0 +1,34 @@
+# Commit Message Template
+
+## Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+## Types
+
+- **feat**: A new feature
+- **fix**: A bug fix
+- **docs**: Documentation only changes
+- **style**: Changes that do not affect the meaning of the code
+- **refactor**: A code change that neither fixes a bug nor adds a feature
+- **perf**: A code change that improves performance
+- **test**: Adding missing tests or correcting existing tests
+- **chore**: Changes to the build process or auxiliary tools
+
+## Example
+
+```
+feat(auth): add OAuth2 login support
+
+- Add Google OAuth2 provider
+- Add session management
+- Update user model with oauth fields
+
+Closes #123
+```

--- a/src/skills/loader.py
+++ b/src/skills/loader.py
@@ -1,0 +1,127 @@
+"""Progressive skill loader."""
+
+import logging
+
+from skills.registry import SkillRegistry
+from skills.types import Skill, SkillContent
+
+logger = logging.getLogger(__name__)
+
+# Maximum content size per skill in bytes.
+MAX_CONTENT_SIZE = 32 * 1024  # 32KB
+
+
+class SkillLoader:
+    """Progressive skill loader.
+
+    Loads full skill content on demand, with caching and unloading support.
+    """
+
+    def __init__(self, registry: SkillRegistry):
+        """Initialize the loader.
+
+        Args:
+            registry: Skill registry.
+        """
+        self.registry = registry
+        self._content_cache: dict[str, SkillContent] = {}
+
+    def load_content(self, skill_id: str) -> SkillContent | None:
+        """Load the full content of a skill on demand.
+
+        Args:
+            skill_id: Skill ID.
+
+        Returns:
+            Skill content, or None if not found.
+        """
+        # Check cache
+        if skill_id in self._content_cache:
+            logger.debug(f"Returning cached content for skill: {skill_id}")
+            return self._content_cache[skill_id]
+
+        skill = self.registry.get(skill_id)
+        if not skill:
+            logger.warning(f"Skill not found: {skill_id}")
+            return None
+
+        skill_md = skill.path / "SKILL.md"
+        if not skill_md.exists():
+            logger.warning(f"SKILL.md not found: {skill_md}")
+            return None
+
+        try:
+            raw = skill_md.read_text(encoding="utf-8")
+            content = self._parse_content(raw)
+
+            # Truncate overly long content
+            if len(content.instructions) > MAX_CONTENT_SIZE:
+                content.instructions = content.instructions[:MAX_CONTENT_SIZE] + "\n...[truncated]"
+                logger.warning(f"Skill content truncated: {skill_id}")
+
+            # Update cache and state
+            self._content_cache[skill_id] = content
+            skill.content = content
+            skill.loaded = True
+
+            logger.info(f"Loaded skill content: {skill_id} ({len(content.instructions)} bytes)")
+            return content
+
+        except Exception as e:
+            logger.error(f"Failed to load skill content for {skill_id}: {e}")
+            return None
+
+    def _parse_content(self, raw: str) -> SkillContent:
+        """Parse SKILL.md content (skip frontmatter).
+
+        Args:
+            raw: Raw file content.
+
+        Returns:
+            Parsed SkillContent.
+        """
+        if raw.startswith("---"):
+            parts = raw.split("---", 2)
+            body = parts[2].strip() if len(parts) >= 3 else ""
+        else:
+            body = raw.strip()
+
+        return SkillContent(instructions=body)
+
+    def unload(self, skill_id: str) -> None:
+        """Unload skill content (free memory).
+
+        Args:
+            skill_id: Skill ID.
+        """
+        if skill_id in self._content_cache:
+            del self._content_cache[skill_id]
+            logger.debug(f"Unloaded skill content from cache: {skill_id}")
+
+        skill = self.registry.get(skill_id)
+        if skill:
+            skill.content = None
+            skill.loaded = False
+
+    def unload_all(self) -> None:
+        """Unload all skill content."""
+        self._content_cache.clear()
+        for skill in self.registry.list_all():
+            skill.content = None
+            skill.loaded = False
+        logger.info("Unloaded all skill contents")
+
+    def is_loaded(self, skill_id: str) -> bool:
+        """Check if a skill's content has been loaded.
+
+        Args:
+            skill_id: Skill ID.
+
+        Returns:
+            Whether the full content is loaded.
+        """
+        return skill_id in self._content_cache
+
+    def get_loaded_skills(self) -> list[Skill]:
+        """Get all skills whose content has been loaded."""
+        return [skill for skill in self.registry.list_all() if skill.loaded]

--- a/src/skills/matcher.py
+++ b/src/skills/matcher.py
@@ -1,0 +1,143 @@
+"""Skill semantic matcher."""
+
+import fnmatch
+import logging
+from collections.abc import Callable
+
+from skills.registry import SkillRegistry
+from skills.types import Skill
+
+logger = logging.getLogger(__name__)
+
+
+class SkillMatcher:
+    """Skill semantic matcher.
+
+    Finds matching skills based on task descriptions, file paths, etc.
+    Supports keyword matching, path glob matching, and extensible semantic scoring.
+    """
+
+    def __init__(self, registry: SkillRegistry):
+        """Initialize the matcher.
+
+        Args:
+            registry: Skill registry.
+        """
+        self.registry = registry
+
+    def find_matching_skills(
+        self,
+        query: str,
+        context_paths: list[str] | None = None,
+        semantic_scorer: Callable[[str, str], float] | None = None,
+        min_score: float = 0.1,
+    ) -> list[tuple[str, float]]:
+        """Find skills matching a query.
+
+        Args:
+            query: User query or task description.
+            context_paths: File paths involved in the current context.
+            semantic_scorer: Optional semantic scoring function (query, skill_desc) -> score.
+            min_score: Minimum match score threshold.
+
+        Returns:
+            [(skill_id, score), ...] sorted by score descending.
+        """
+        matches: list[tuple[str, float]] = []
+
+        for skill in self.registry.list_all():
+            score = self._calculate_match_score(skill, query, context_paths, semantic_scorer)
+            if score >= min_score:
+                matches.append((skill.id, score))
+
+        matches.sort(key=lambda x: x[1], reverse=True)
+        logger.debug(f"Found {len(matches)} matching skills for query: {query[:50]}...")
+        return matches
+
+    def _calculate_match_score(
+        self,
+        skill: Skill,
+        query: str,
+        paths: list[str] | None,
+        semantic_scorer: Callable[[str, str], float] | None,
+    ) -> float:
+        """Calculate the match score for a single skill.
+
+        Args:
+            skill: Skill object.
+            query: Query string.
+            paths: File path list.
+            semantic_scorer: Semantic scoring function.
+
+        Returns:
+            Match score (0.0+, higher is better).
+        """
+        score = 0.0
+        query_lower = query.lower()
+
+        for trigger in skill.metadata.triggers:
+            trigger_type = trigger.get("type", "manual")
+
+            if trigger_type == "always":
+                score += 1.0
+
+            elif trigger_type == "semantic":
+                # Keyword matching
+                keywords = trigger.get("keywords", [])
+                for kw in keywords:
+                    if kw.lower() in query_lower:
+                        score += 0.5
+
+                # Use external semantic scorer (e.g. embedding similarity)
+                if semantic_scorer and skill.metadata.description:
+                    try:
+                        sem_score = semantic_scorer(query, skill.metadata.description)
+                        score += sem_score * 0.8
+                    except Exception as e:
+                        logger.warning(f"Semantic scorer failed: {e}")
+
+            elif trigger_type == "path_glob" and paths:
+                # Path glob matching
+                pattern = trigger.get("pattern", "")
+                for path in paths:
+                    normalized_path = path.replace("\\", "/")
+                    if fnmatch.fnmatch(normalized_path, pattern):
+                        score += 0.6
+                        break  # One path match is enough
+
+        return score
+
+    def get_always_active_skills(self) -> list[Skill]:
+        """Get all skills with an "always" trigger.
+
+        Returns:
+            List of always-active skills.
+        """
+        result = []
+        for skill in self.registry.list_all():
+            for trigger in skill.metadata.triggers:
+                if trigger.get("type") == "always":
+                    result.append(skill)
+                    break
+        return result
+
+    def get_skills_for_path(self, file_path: str) -> list[Skill]:
+        """Get skills matching a given file path.
+
+        Args:
+            file_path: File path to match.
+
+        Returns:
+            List of matching skills.
+        """
+        result = []
+        normalized_path = file_path.replace("\\", "/")
+
+        for skill in self.registry.list_all():
+            for trigger in skill.metadata.triggers:
+                if trigger.get("type") == "path_glob":
+                    pattern = trigger.get("pattern", "")
+                    if fnmatch.fnmatch(normalized_path, pattern):
+                        result.append(skill)
+                        break
+        return result

--- a/src/skills/registry.py
+++ b/src/skills/registry.py
@@ -1,0 +1,123 @@
+"""Skill registry - discovers and manages all skills."""
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from skills.types import Skill, SkillMetadata
+
+logger = logging.getLogger(__name__)
+
+
+class SkillRegistry:
+    """Skill registry.
+
+    Scans skill directories, parses SKILL.md frontmatter, and registers all skills.
+    Supports multi-level directory scanning with hierarchical override
+    (later directories override earlier ones with the same skill ID).
+
+    Priority (low to high):
+    1. Global skill directory (src/skills/catalog/)
+    2. Agent-specific directory (src/agents/{agent}/skills/)
+    3. Session-level (dynamically injected via the register method)
+    """
+
+    def __init__(self, *skill_roots: Path):
+        """Initialize the registry.
+
+        Args:
+            skill_roots: Skill directory root paths, ordered by priority (low to high).
+        """
+        self.skill_roots = list(skill_roots)
+        self._skills: dict[str, Skill] = {}
+
+    def scan(self) -> None:
+        """Scan all skill directories and load metadata (later entries override earlier ones)."""
+        for root in self.skill_roots:
+            self._scan_directory(root)
+
+        logger.info(f"Scanned {len(self._skills)} skills from {len(self.skill_roots)} directories")
+
+    def _scan_directory(self, root: Path) -> None:
+        """Scan a single directory."""
+        if not root.exists():
+            logger.debug(f"Skills directory not found: {root}")
+            return
+
+        for skill_dir in root.iterdir():
+            if skill_dir.is_dir():
+                skill_md = skill_dir / "SKILL.md"
+                if skill_md.exists():
+                    self._register_skill(skill_dir, skill_md)
+
+    def _register_skill(self, skill_dir: Path, skill_md: Path) -> None:
+        """Register a single skill (metadata only)."""
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+            metadata = self._parse_frontmatter(content)
+
+            skill = Skill(
+                id=skill_dir.name,
+                path=skill_dir,
+                metadata=metadata,
+                content=None,  # Lazily loaded
+                loaded=False,
+            )
+            self._skills[skill.id] = skill
+            logger.debug(f"Registered skill: {skill.id}")
+
+        except Exception as e:
+            logger.error(f"Failed to register skill from {skill_dir}: {e}")
+
+    def _parse_frontmatter(self, content: str) -> SkillMetadata:
+        """Parse YAML frontmatter from a SKILL.md file.
+
+        Args:
+            content: Raw SKILL.md file content.
+
+        Returns:
+            Parsed SkillMetadata.
+        """
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            if len(parts) >= 3:
+                try:
+                    meta = yaml.safe_load(parts[1]) or {}
+                    return SkillMetadata(
+                        name=meta.get("name", "Unknown"),
+                        description=meta.get("description", ""),
+                        version=meta.get("version", "1.0"),
+                        triggers=meta.get("triggers", []),
+                        resources=meta.get("resources", []),
+                        dependencies=meta.get("dependencies", []),
+                    )
+                except yaml.YAMLError as e:
+                    logger.warning(f"Failed to parse YAML frontmatter: {e}")
+
+        return SkillMetadata(name="Unknown", description="")
+
+    def get(self, skill_id: str) -> Skill | None:
+        """Get a skill by ID.
+
+        Args:
+            skill_id: Skill ID.
+
+        Returns:
+            The Skill object, or None if not found.
+        """
+        return self._skills.get(skill_id)
+
+    def list_all(self) -> list[Skill]:
+        """List all registered skills."""
+        return list(self._skills.values())
+
+    def list_metadata(self) -> list[SkillMetadata]:
+        """Return only the metadata list (lightweight)."""
+        return [s.metadata for s in self._skills.values()]
+
+    def __len__(self) -> int:
+        return len(self._skills)
+
+    def __contains__(self, skill_id: str) -> bool:
+        return skill_id in self._skills

--- a/src/skills/resources.py
+++ b/src/skills/resources.py
@@ -1,0 +1,213 @@
+"""Resource resolution and script execution."""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from skills.registry import SkillRegistry
+from skills.types import Resource
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceResolver:
+    """Resource resolver.
+
+    Handles additional resources (scripts, templates, data files) in skill directories.
+    """
+
+    def __init__(self, registry: SkillRegistry):
+        """Initialize the resource resolver.
+
+        Args:
+            registry: Skill registry.
+        """
+        self.registry = registry
+
+    def resolve(self, skill_id: str, resource_name: str) -> Resource | None:
+        """Resolve a resource path.
+
+        Args:
+            skill_id: Skill ID.
+            resource_name: Relative path to the resource.
+
+        Returns:
+            Resource object, or None if not found.
+        """
+        skill = self.registry.get(skill_id)
+        if not skill:
+            return None
+
+        resource_path = skill.path / resource_name
+        if not resource_path.exists():
+            return None
+
+        # Infer resource type
+        suffix = resource_path.suffix.lower()
+        if suffix in (".py", ".sh", ".ps1", ".bat", ".cmd"):
+            rtype = "script"
+        elif suffix in (".md", ".txt", ".j2", ".jinja2", ".template"):
+            rtype = "template"
+        else:
+            rtype = "data"
+
+        return Resource(
+            name=resource_name,
+            path=resource_path,
+            resource_type=rtype,
+        )
+
+    def read_resource(self, skill_id: str, resource_name: str) -> str | None:
+        """Read the content of a resource.
+
+        Args:
+            skill_id: Skill ID.
+            resource_name: Relative path to the resource.
+
+        Returns:
+            Resource content, or None if not found.
+        """
+        resource = self.resolve(skill_id, resource_name)
+        if resource and resource.path.is_file():
+            try:
+                return resource.path.read_text(encoding="utf-8")
+            except Exception as e:
+                logger.error(f"Failed to read resource {skill_id}/{resource_name}: {e}")
+                return None
+        return None
+
+    def list_resources(self, skill_id: str) -> list[Resource]:
+        """List all declared resources for a skill.
+
+        Args:
+            skill_id: Skill ID.
+
+        Returns:
+            List of resources.
+        """
+        skill = self.registry.get(skill_id)
+        if not skill:
+            return []
+
+        resources = []
+        for res_name in skill.metadata.resources:
+            res = self.resolve(skill_id, res_name)
+            if res:
+                resources.append(res)
+        return resources
+
+    def list_all_files(self, skill_id: str) -> list[Resource]:
+        """List all files in the skill directory.
+
+        Args:
+            skill_id: Skill ID.
+
+        Returns:
+            List of all file resources.
+        """
+        skill = self.registry.get(skill_id)
+        if not skill:
+            return []
+
+        resources = []
+        for file_path in skill.path.rglob("*"):
+            if file_path.is_file() and file_path.name != "SKILL.md":
+                rel_path = file_path.relative_to(skill.path)
+                res = self.resolve(skill_id, str(rel_path))
+                if res:
+                    resources.append(res)
+        return resources
+
+
+class ScriptExecutor:
+    """Script executor.
+
+    Safely executes scripts from skill directories.
+    """
+
+    def __init__(
+        self,
+        allowed_extensions: set[str] | None = None,
+        default_timeout: int = 30,
+    ):
+        """Initialize the script executor.
+
+        Args:
+            allowed_extensions: Set of allowed file extensions.
+            default_timeout: Default execution timeout in seconds.
+        """
+        self.allowed = allowed_extensions or {".py", ".sh"}
+        self.default_timeout = default_timeout
+
+    def execute(
+        self,
+        script_path: Path,
+        args: list[str] | None = None,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Execute a script and return the result.
+
+        Args:
+            script_path: Path to the script.
+            args: Script arguments.
+            timeout: Timeout in seconds.
+            env: Environment variables.
+
+        Returns:
+            Result dict with stdout, stderr, returncode, or error.
+        """
+        if script_path.suffix not in self.allowed:
+            return {"error": f"Script type not allowed: {script_path.suffix}"}
+
+        if not script_path.exists():
+            return {"error": f"Script not found: {script_path}"}
+
+        timeout = timeout or self.default_timeout
+
+        try:
+            # Build command based on script type
+            if script_path.suffix == ".py":
+                cmd = ["python", str(script_path)] + (args or [])
+            elif script_path.suffix == ".sh":
+                cmd = ["bash", str(script_path)] + (args or [])
+            elif script_path.suffix in (".ps1",):
+                cmd = ["powershell", "-File", str(script_path)] + (args or [])
+            else:
+                cmd = [str(script_path)] + (args or [])
+
+            logger.info(f"Executing script: {' '.join(cmd)}")
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=script_path.parent,
+                env=env,
+            )
+
+            return {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.returncode,
+            }
+
+        except subprocess.TimeoutExpired:
+            logger.warning(f"Script timed out after {timeout}s: {script_path}")
+            return {"error": f"Script timed out after {timeout}s"}
+        except Exception as e:
+            logger.error(f"Script execution failed: {e}")
+            return {"error": str(e)}
+
+    def is_allowed(self, script_path: Path) -> bool:
+        """Check if a script is allowed to execute.
+
+        Args:
+            script_path: Path to the script.
+
+        Returns:
+            Whether the script is allowed.
+        """
+        return script_path.suffix in self.allowed

--- a/src/skills/toolkit.py
+++ b/src/skills/toolkit.py
@@ -1,0 +1,276 @@
+"""Skill toolkit - Agent-callable skill tools."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated
+
+from langchain_core.tools import tool
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Global skill system instance
+_skill_system: SkillSystem | None = None
+
+
+class SkillSystem:
+    """Skill system facade.
+
+    Integrates all skill-related components and provides a unified interface.
+    Supports multi-level directory scanning with hierarchical override.
+    """
+
+    def __init__(self, *skill_roots: Path):
+        """Initialize the skill system.
+
+        Args:
+            *skill_roots: Skill directory root paths, ordered by priority (low to high).
+        """
+        from skills.loader import SkillLoader
+        from skills.matcher import SkillMatcher
+        from skills.registry import SkillRegistry
+        from skills.resources import ResourceResolver, ScriptExecutor
+
+        self.skill_roots = list(skill_roots)
+        self.registry = SkillRegistry(*skill_roots)
+        self.loader = SkillLoader(self.registry)
+        self.matcher = SkillMatcher(self.registry)
+        self.resolver = ResourceResolver(self.registry)
+        self.executor = ScriptExecutor()
+
+        # Scan and load metadata at startup
+        self.registry.scan()
+        logger.info(
+            f"SkillSystem initialized with {len(self.registry)} skills "
+            f"from {len(self.skill_roots)} directories"
+        )
+
+    def reload(self) -> None:
+        """Re-scan and reload skills."""
+        self.loader.unload_all()
+        self.registry.scan()
+        logger.info(f"SkillSystem reloaded with {len(self.registry)} skills")
+
+
+def init_skill_system(
+    global_root: Path,
+    agent_root: Path | None = None,
+) -> SkillSystem:
+    """Initialize the global skill system (call at service startup).
+
+    Args:
+        global_root: Global skill catalog root path.
+        agent_root: Agent-specific skill directory (optional, higher priority).
+
+    Returns:
+        The SkillSystem instance.
+    """
+    global _skill_system
+    roots = [global_root]
+    if agent_root and agent_root.exists():
+        roots.append(agent_root)
+    _skill_system = SkillSystem(*roots)
+    return _skill_system
+
+
+def get_skill_system() -> SkillSystem | None:
+    """Get the global skill system instance."""
+    return _skill_system
+
+
+# ============================================================
+# LangChain tool definitions
+# ============================================================
+
+
+@tool
+def list_available_skills() -> str:
+    """List all available skills and their descriptions.
+
+    Use this to discover what skills are available to help with the current task.
+    Returns a list of skills including skill ID, load status, and description.
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    skills = _skill_system.registry.list_all()
+    if not skills:
+        return "No skills available"
+
+    lines = ["## Available Skills\n"]
+    for s in skills:
+        status = "✓ loaded" if s.loaded else "○ not loaded"
+        lines.append(f"- **{s.id}** [{status}]")
+        lines.append(f"  - {s.metadata.description}")
+    return "\n".join(lines)
+
+
+@tool
+def find_skills_for_task(
+    task_description: Annotated[str, "Description of the current task"],
+    file_paths: Annotated[list[str] | None, "List of involved file paths (optional)"] = None,
+) -> str:
+    """Find skills relevant to a task description.
+
+    Analyzes the task description and involved file paths, returning skills
+    sorted by relevance. Use this before starting a task to identify which
+    skill guides to consult.
+
+    Args:
+        task_description: Description of the current task.
+        file_paths: List of involved file paths (optional).
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    matches = _skill_system.matcher.find_matching_skills(
+        task_description,
+        file_paths,
+    )
+
+    if not matches:
+        return "No skills found matching the task"
+
+    lines = ["## Relevant Skills (by match score)\n"]
+    for skill_id, score in matches[:5]:  # Return at most 5
+        skill = _skill_system.registry.get(skill_id)
+        if skill:
+            lines.append(f"- **{skill_id}** (score: {score:.2f})")
+            lines.append(f"  - {skill.metadata.description}")
+    return "\n".join(lines)
+
+
+@tool
+def load_skill(
+    skill_id: Annotated[str, "ID of the skill to load"],
+) -> str:
+    """Load the full instruction content of a skill.
+
+    Only call this when you are sure you need a particular skill.
+    Returns the skill's detailed instructions and best practices.
+
+    Args:
+        skill_id: ID of the skill to load.
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    skill = _skill_system.registry.get(skill_id)
+    if not skill:
+        return f"Skill not found: {skill_id}"
+
+    content = _skill_system.loader.load_content(skill_id)
+    if not content:
+        return f"Failed to load skill content: {skill_id}"
+
+    return f"# Skill: {skill.metadata.name}\n\n{content.instructions}"
+
+
+@tool
+def get_skill_resource(
+    skill_id: Annotated[str, "Skill ID"],
+    resource_name: Annotated[str, "Relative path to the resource, e.g. 'scripts/lint.py'"],
+) -> str:
+    """Read a resource file from a skill directory.
+
+    Use this to read templates, configuration files, or other auxiliary files.
+    The resource path is relative to the skill directory.
+
+    Args:
+        skill_id: Skill ID.
+        resource_name: Relative path to the resource file.
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    content = _skill_system.resolver.read_resource(skill_id, resource_name)
+    if not content:
+        return f"Resource not found: {skill_id}/{resource_name}"
+    return content
+
+
+@tool
+def list_skill_resources(
+    skill_id: Annotated[str, "Skill ID"],
+) -> str:
+    """List all resource files in a skill directory.
+
+    Shows scripts, templates, and data files included with the skill.
+
+    Args:
+        skill_id: Skill ID.
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    skill = _skill_system.registry.get(skill_id)
+    if not skill:
+        return f"Skill not found: {skill_id}"
+
+    resources = _skill_system.resolver.list_all_files(skill_id)
+    if not resources:
+        return f"Skill {skill_id} has no additional resource files"
+
+    lines = [f"## Resources for skill {skill_id}\n"]
+    for res in resources:
+        lines.append(f"- [{res.resource_type}] `{res.name}`")
+    return "\n".join(lines)
+
+
+@tool
+def run_skill_script(
+    skill_id: Annotated[str, "Skill ID"],
+    script_name: Annotated[str, "Relative path to the script file"],
+    args: Annotated[list[str] | None, "Script arguments (optional)"] = None,
+) -> str:
+    """Execute a script from a skill directory.
+
+    ⚠️ Use with caution — only call when explicitly needed.
+    Scripts must be .py or .sh files (Windows also supports .ps1).
+
+    Args:
+        skill_id: Skill ID.
+        script_name: Relative path to the script file.
+        args: Script arguments (optional).
+    """
+    if not _skill_system:
+        return "Skill system not initialized"
+
+    resource = _skill_system.resolver.resolve(skill_id, script_name)
+    if not resource:
+        return f"Script not found: {skill_id}/{script_name}"
+
+    if resource.resource_type != "script":
+        return f"Resource is not a script: {skill_id}/{script_name}"
+
+    if not _skill_system.executor.is_allowed(resource.path):
+        return f"Script type not allowed: {resource.path.suffix}"
+
+    result = _skill_system.executor.execute(resource.path, args)
+
+    if "error" in result:
+        return f"Execution error: {result['error']}"
+
+    output_parts = []
+    if result.get("stdout"):
+        output_parts.append(f"**Output:**\n```\n{result['stdout']}\n```")
+    if result.get("stderr"):
+        output_parts.append(f"**Stderr:**\n```\n{result['stderr']}\n```")
+    output_parts.append(f"**Exit code:** {result.get('returncode', 'unknown')}")
+
+    return "\n\n".join(output_parts) if output_parts else "(no output)"
+
+
+# Export all skill tools
+skill_tools = [
+    list_available_skills,
+    find_skills_for_task,
+    load_skill,
+    get_skill_resource,
+    list_skill_resources,
+    run_skill_script,
+]

--- a/src/skills/types.py
+++ b/src/skills/types.py
@@ -1,0 +1,82 @@
+"""Core type definitions for the skill system."""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class TriggerType(Enum):
+    """Trigger type enumeration."""
+
+    ALWAYS = "always"  # Always loaded
+    MANUAL = "manual"  # Manually triggered
+    SEMANTIC = "semantic"  # Semantic match trigger
+    PATH_GLOB = "path_glob"  # Path glob match trigger
+
+
+@dataclass
+class SkillMetadata:
+    """Skill metadata (lightweight, loaded at startup).
+
+    Attributes:
+        name: Skill name.
+        description: Skill description.
+        version: Version string.
+        triggers: List of trigger rules.
+        resources: List of resource file paths.
+        dependencies: List of dependent skill IDs.
+    """
+
+    name: str
+    description: str
+    version: str = "1.0"
+    triggers: list[dict] = field(default_factory=list)
+    resources: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SkillContent:
+    """Full skill content (loaded on demand).
+
+    Attributes:
+        instructions: Primary instruction content.
+        examples: List of usage examples.
+    """
+
+    instructions: str
+    examples: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Skill:
+    """Complete skill object.
+
+    Attributes:
+        id: Unique identifier, e.g. "git_operations".
+        path: Directory containing SKILL.md.
+        metadata: Skill metadata.
+        content: Full content (lazily loaded).
+        loaded: Whether full content has been loaded.
+    """
+
+    id: str
+    path: Path
+    metadata: SkillMetadata
+    content: SkillContent | None = None
+    loaded: bool = False
+
+
+@dataclass
+class Resource:
+    """Resource reference.
+
+    Attributes:
+        name: Resource name.
+        path: Full path to the resource.
+        resource_type: Resource type (script/template/data).
+    """
+
+    name: str
+    path: Path
+    resource_type: str  # "script" | "template" | "data"

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -177,6 +177,25 @@ async def main() -> None:
                 "Prompts, responses and feedback in this app are anonymously recorded and saved to LangSmith for product evaluation and improvement purposes only."
             )
 
+        # Skill system status display
+        with st.popover(":material/extension: Skills", use_container_width=True):
+            try:
+                from skills.toolkit import get_skill_system
+
+                skill_system = get_skill_system()
+                if skill_system:
+                    skills = skill_system.registry.list_all()
+                    if skills:
+                        for s in skills:
+                            status = "✅" if s.loaded else "○"
+                            st.text(f"{status} {s.id}")
+                    else:
+                        st.caption("No skills available")
+                else:
+                    st.caption("Skill system not initialized")
+            except ImportError:
+                st.caption("Skill module not available")
+
         @st.dialog("Share/resume chat")
         def share_chat_dialog() -> None:
             session = st.runtime.get_instance()._session_mgr.list_active_sessions()[0]

--- a/tests/skills/test_skill_system.py
+++ b/tests/skills/test_skill_system.py
@@ -1,0 +1,312 @@
+"""Skill system unit tests."""
+
+from pathlib import Path
+
+import pytest
+
+from skills.loader import SkillLoader
+from skills.matcher import SkillMatcher
+from skills.registry import SkillRegistry
+from skills.resources import ResourceResolver, ScriptExecutor
+from skills.toolkit import SkillSystem, get_skill_system, init_skill_system
+from skills.types import SkillMetadata
+
+
+@pytest.fixture
+def sample_skills_dir(tmp_path: Path) -> Path:
+    """Create a sample skills directory for testing."""
+    # Create test_skill
+    skill_dir = tmp_path / "test_skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: Test Skill
+description: A test skill for unit testing
+version: "1.0"
+triggers:
+  - type: semantic
+    keywords: ["test", "example", "demo"]
+  - type: path_glob
+    pattern: "**/*.test.py"
+resources:
+  - scripts/helper.py
+---
+
+# Test Skill Instructions
+
+This is the instruction content for testing.
+
+## Usage
+
+Use this skill when you need to test something.
+""",
+        encoding="utf-8",
+    )
+
+    # Create scripts directory and file
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "helper.py").write_text(
+        """#!/usr/bin/env python3
+print("Hello from helper script!")
+""",
+        encoding="utf-8",
+    )
+
+    # Create always_skill
+    always_dir = tmp_path / "always_skill"
+    always_dir.mkdir()
+    (always_dir / "SKILL.md").write_text(
+        """---
+name: Always Active Skill
+description: A skill that is always active
+triggers:
+  - type: always
+---
+
+# Always Active
+
+This skill is always loaded.
+""",
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+class TestSkillRegistry:
+    """Test the skill registry."""
+
+    def test_scan_discovers_skills(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        assert len(registry) == 2
+        assert "test_skill" in registry
+        assert "always_skill" in registry
+
+    def test_get_skill(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+
+        skill = registry.get("test_skill")
+        assert skill is not None
+        assert skill.metadata.name == "Test Skill"
+        assert skill.metadata.version == "1.0"
+        assert len(skill.metadata.triggers) == 2
+
+    def test_list_all(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+
+        skills = registry.list_all()
+        assert len(skills) == 2
+
+    def test_list_metadata(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+
+        metadata_list = registry.list_metadata()
+        assert len(metadata_list) == 2
+        assert all(isinstance(m, SkillMetadata) for m in metadata_list)
+
+    def test_empty_directory(self, tmp_path: Path):
+        registry = SkillRegistry(tmp_path)
+        registry.scan()
+        assert len(registry) == 0
+
+    def test_nonexistent_directory(self, tmp_path: Path):
+        registry = SkillRegistry(tmp_path / "nonexistent")
+        registry.scan()
+        assert len(registry) == 0
+
+
+class TestSkillLoader:
+    """Test the skill loader."""
+
+    def test_load_content(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        loader = SkillLoader(registry)
+
+        content = loader.load_content("test_skill")
+        assert content is not None
+        assert "Test Skill Instructions" in content.instructions
+
+    def test_lazy_loading(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        loader = SkillLoader(registry)
+
+        skill = registry.get("test_skill")
+        assert not skill.loaded
+        assert skill.content is None
+
+        loader.load_content("test_skill")
+        assert skill.loaded
+        assert skill.content is not None
+
+    def test_cache(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        loader = SkillLoader(registry)
+
+        content1 = loader.load_content("test_skill")
+        content2 = loader.load_content("test_skill")
+        assert content1 is content2
+
+    def test_unload(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        loader = SkillLoader(registry)
+
+        loader.load_content("test_skill")
+        assert loader.is_loaded("test_skill")
+
+        loader.unload("test_skill")
+        assert not loader.is_loaded("test_skill")
+
+    def test_nonexistent_skill(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        loader = SkillLoader(registry)
+
+        content = loader.load_content("nonexistent")
+        assert content is None
+
+
+class TestSkillMatcher:
+    """Test the skill matcher."""
+
+    def test_semantic_matching(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        matcher = SkillMatcher(registry)
+
+        matches = matcher.find_matching_skills("I need to test something")
+        assert len(matches) > 0
+        skill_ids = [m[0] for m in matches]
+        assert "test_skill" in skill_ids
+
+    def test_path_matching(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        matcher = SkillMatcher(registry)
+
+        matches = matcher.find_matching_skills(
+            "run some code",
+            context_paths=["src/utils/helper.test.py"],
+        )
+        skill_ids = [m[0] for m in matches]
+        assert "test_skill" in skill_ids
+
+    def test_always_trigger(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        matcher = SkillMatcher(registry)
+
+        always_skills = matcher.get_always_active_skills()
+        assert len(always_skills) == 1
+        assert always_skills[0].id == "always_skill"
+
+    def test_no_matches(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        matcher = SkillMatcher(registry)
+
+        matches = matcher.find_matching_skills("completely unrelated query xyz123")
+        # always_skill will match because it has an "always" trigger
+        skill_ids = [m[0] for m in matches]
+        assert "always_skill" in skill_ids
+
+
+class TestResourceResolver:
+    """Test the resource resolver."""
+
+    def test_resolve_script(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        resolver = ResourceResolver(registry)
+
+        resource = resolver.resolve("test_skill", "scripts/helper.py")
+        assert resource is not None
+        assert resource.resource_type == "script"
+
+    def test_read_resource(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        resolver = ResourceResolver(registry)
+
+        content = resolver.read_resource("test_skill", "scripts/helper.py")
+        assert content is not None
+        assert "Hello from helper script" in content
+
+    def test_list_resources(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        resolver = ResourceResolver(registry)
+
+        resources = resolver.list_resources("test_skill")
+        assert len(resources) == 1
+        assert resources[0].name == "scripts/helper.py"
+
+    def test_nonexistent_resource(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+        resolver = ResourceResolver(registry)
+
+        resource = resolver.resolve("test_skill", "nonexistent.py")
+        assert resource is None
+
+
+class TestScriptExecutor:
+    """Test the script executor."""
+
+    def test_execute_python_script(self, sample_skills_dir: Path):
+        registry = SkillRegistry(sample_skills_dir)
+        registry.scan()
+
+        script_path = sample_skills_dir / "test_skill" / "scripts" / "helper.py"
+        executor = ScriptExecutor()
+
+        result = executor.execute(script_path)
+        assert "error" not in result
+        assert "Hello from helper script" in result["stdout"]
+        assert result["returncode"] == 0
+
+    def test_disallowed_extension(self, sample_skills_dir: Path):
+        executor = ScriptExecutor()
+        fake_path = sample_skills_dir / "test.exe"
+        fake_path.touch()
+
+        result = executor.execute(fake_path)
+        assert "error" in result
+        assert "not allowed" in result["error"]
+
+    def test_is_allowed(self):
+        executor = ScriptExecutor(allowed_extensions={".py", ".sh"})
+        assert executor.is_allowed(Path("test.py"))
+        assert executor.is_allowed(Path("test.sh"))
+        assert not executor.is_allowed(Path("test.exe"))
+
+
+class TestSkillSystem:
+    """Test the skill system facade."""
+
+    def test_init(self, sample_skills_dir: Path):
+        system = SkillSystem(sample_skills_dir)
+        assert len(system.registry) == 2
+        assert system.loader is not None
+        assert system.matcher is not None
+        assert system.resolver is not None
+
+    def test_global_instance(self, sample_skills_dir: Path):
+        system = init_skill_system(sample_skills_dir)
+        assert get_skill_system() is system
+
+    def test_reload(self, sample_skills_dir: Path):
+        system = SkillSystem(sample_skills_dir)
+        system.loader.load_content("test_skill")
+        assert system.loader.is_loaded("test_skill")
+
+        system.reload()
+        assert not system.loader.is_loaded("test_skill")


### PR DESCRIPTION
## Summary

Add a plugin-style skill system inspired by GitHub Copilot / Cursor Rules / AGENTS.md that allows agents to dynamically discover, load, and execute structured instructions and scripts.

## Core Components

- **SkillRegistry**: Multi-directory scanning with hierarchical override
- **SkillLoader**: Progressive/lazy content loading with 32KB cap
- **SkillMatcher**: Keyword, path glob, and extensible semantic matching
- **ResourceResolver + ScriptExecutor**: Resource file access and safe script execution
- **SkillSystem facade**: Unified interface + 6 LangChain tools for agent integration

## What's Included

- `src/skills/` — Full skill system module
- [src/skills/catalog/git_operations/](cci:9://file:///d:/code/agent-service-toolkit/src/skills/catalog/git_operations:0:0-0:0) — Example skill with commit check script and templates
- [src/streamlit_app.py](cci:7://file:///d:/code/agent-service-toolkit/src/streamlit_app.py:0:0-0:0) — Sidebar "Skills" popover showing skill load status
- [tests/skills/test_skill_system.py](cci:7://file:///d:/code/agent-service-toolkit/tests/skills/test_skill_system.py:0:0-0:0) — 25 unit tests covering all components
- [docs/Skill_System.md](cci:7://file:///d:/code/agent-service-toolkit/docs/Skill_System.md:0:0-0:0) — Feature documentation

## Testing

```bash
pytest tests/skills/test_skill_system.py -v
# 25 passed

---
 
## Note
 
Thank you for building and maintaining this excellent toolkit — it's been a great learning resource and foundation for exploring LangGraph-based agent architectures. 
 
This is my first contribution to this project. I'd love to hear your feedback on the design and implementation. Happy to adjust anything based on your preferences and project direction.