### PR TITLE
fix: prevent Anthropic "multiple non-consecutive system messages" error

### DIFF
--- a/src/agents/knowledge_base_agent.py
+++ b/src/agents/knowledge_base_agent.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from langchain_aws import AmazonKnowledgeBasesRetriever
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSerializable
 from langchain_core.runnables.base import RunnableSequence
 from langgraph.graph import END, MessagesState, StateGraph
@@ -47,7 +47,7 @@ def get_kb_retriever():
 def wrap_model(model: BaseChatModel) -> RunnableSerializable[AgentState, AIMessage]:
     """Wrap the model with a system prompt for the Knowledge Base agent."""
 
-    def create_system_message(state):
+    def create_system_message(state) -> list[BaseMessage]:
         base_prompt = """You are a helpful assistant that provides accurate information based on retrieved documents.
 
         You will receive a query along with relevant documents retrieved from a knowledge base. Use these documents to inform your response.
@@ -63,17 +63,19 @@ def wrap_model(model: BaseChatModel) -> RunnableSerializable[AgentState, AIMessa
         Format your response in a clear, conversational manner. Use markdown formatting when appropriate.
         """
 
+        # Filter out any SystemMessages already in history to avoid Anthropic's
+        # "multiple non-consecutive system messages" error (issue #280).
+        non_system = [m for m in state["messages"] if not isinstance(m, SystemMessage)]
+
         # Check if documents were retrieved
         if "kb_documents" in state:
-            # Append document information to the system prompt
             document_prompt = f"\n\nI've retrieved the following documents that may be relevant to the query:\n\n{state['kb_documents']}\n\nPlease use these documents to inform your response to the user's query. Only use information from these documents and clearly indicate when you are unsure."
-            return [SystemMessage(content=base_prompt + document_prompt)] + state["messages"]
+            return [SystemMessage(content=base_prompt + document_prompt)] + non_system
         else:
-            # No documents were retrieved
             no_docs_prompt = (
                 "\n\nNo relevant documents were found in the knowledge base for this query."
             )
-            return [SystemMessage(content=base_prompt + no_docs_prompt)] + state["messages"]
+            return [SystemMessage(content=base_prompt + no_docs_prompt)] + non_system
 
     preprocessor = RunnableLambda(
         create_system_message,

--- a/src/agents/rag_assistant.py
+++ b/src/agents/rag_assistant.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage
 from langchain_core.runnables import (
     RunnableConfig,
     RunnableLambda,
@@ -47,12 +47,16 @@ instructions = f"""
     """
 
 
+def _build_messages(state: AgentState) -> list[BaseMessage]:
+    # Filter out any SystemMessages already in history to avoid Anthropic's
+    # "multiple non-consecutive system messages" error (issue #280).
+    non_system = [m for m in state["messages"] if not isinstance(m, SystemMessage)]
+    return [SystemMessage(content=instructions)] + non_system
+
+
 def wrap_model(model: BaseChatModel) -> RunnableSerializable[AgentState, AIMessage]:
     bound_model = model.bind_tools(tools)
-    preprocessor = RunnableLambda(
-        lambda state: [SystemMessage(content=instructions)] + state["messages"],
-        name="StateModifier",
-    )
+    preprocessor = RunnableLambda(_build_messages, name="StateModifier")
     return preprocessor | bound_model  # type: ignore[return-value]
 
 

--- a/src/agents/research_assistant.py
+++ b/src/agents/research_assistant.py
@@ -4,7 +4,7 @@ from typing import Literal
 from langchain_community.tools import DuckDuckGoSearchResults, OpenWeatherMapQueryRun
 from langchain_community.utilities import OpenWeatherMapAPIWrapper
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSerializable
 from langgraph.graph import END, MessagesState, StateGraph
 from langgraph.managed import RemainingSteps
@@ -51,12 +51,16 @@ instructions = f"""
     """
 
 
+def _build_messages(state: AgentState) -> list[BaseMessage]:
+    # Filter out any SystemMessages already in history to avoid Anthropic's
+    # "multiple non-consecutive system messages" error (issue #280).
+    non_system = [m for m in state["messages"] if not isinstance(m, SystemMessage)]
+    return [SystemMessage(content=instructions)] + non_system
+
+
 def wrap_model(model: BaseChatModel) -> RunnableSerializable[AgentState, AIMessage]:
     bound_model = model.bind_tools(tools)
-    preprocessor = RunnableLambda(
-        lambda state: [SystemMessage(content=instructions)] + state["messages"],
-        name="StateModifier",
-    )
+    preprocessor = RunnableLambda(_build_messages, name="StateModifier")
     return preprocessor | bound_model  # type: ignore[return-value]
 
 


### PR DESCRIPTION
## Summary

Fixes #280 — Claude/Anthropic models throw `ValueError: Received multiple non-consecutive system messages` when used with this toolkit.

**Root cause:** The `wrap_model` preprocessor in `research_assistant`, `rag_assistant`, and `knowledge_base_agent` prepends a fresh `SystemMessage` to `state["messages"]` on every model call. In multi-agent or supervisor setups a `SystemMessage` can already be present in the persisted conversation history, producing two system messages at non-consecutive positions — which `langchain_anthropic` rejects.

**Fix:** Filter out any pre-existing `SystemMessage` entries from the stored history before prepending the agent's own system prompt, so there is always exactly one `SystemMessage` at position 0.

## Changes

- `src/agents/research_assistant.py` — extract `_build_messages()` helper that strips existing system messages before prepending
- `src/agents/rag_assistant.py` — same pattern
- `src/agents/knowledge_base_agent.py` — same fix inside `create_system_message()`

## Test plan

- [ ] Start a multi-turn conversation using an Anthropic model (e.g. `claude-haiku-4-5`) with the `research-assistant` agent — previously raised `ValueError`, now completes successfully
- [ ] Verify same behaviour for `rag-assistant` and `knowledge-base-agent`
- [ ] Confirm OpenAI models are unaffected (filtering a non-existent type is a no-op)
- [ ] Run existing test suite: `pytest tests/`
