### PR TITLE
fix: send SSE keep-alive pings during long-running agent tool calls

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import json
 import logging
@@ -214,6 +215,52 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
         raise HTTPException(status_code=500, detail="Unexpected error")
 
 
+_SSE_PING = ": ping\n\n"
+_KEEP_ALIVE_INTERVAL = 15  # seconds between pings when the agent is silent
+_STREAM_SENTINEL = object()  # signals end of agent stream inside the queue
+
+
+async def _agent_stream_with_keepalive(
+    agent: "AgentGraph", kwargs: dict[str, Any], interval: float
+) -> AsyncGenerator[Any, None]:
+    """
+    Wrap agent.astream() and inject SSE comment pings during silent gaps.
+
+    Uses a background producer task + asyncio.Queue so that the agent generator
+    is never cancelled mid-flight (unlike asyncio.wait_for on the iterator directly).
+    Each real stream event is yielded as-is; a ping string is yielded instead
+    whenever no event arrives within `interval` seconds.
+    """
+    queue: asyncio.Queue[Any] = asyncio.Queue()
+
+    async def _producer() -> None:
+        try:
+            async for event in agent.astream(
+                **kwargs, stream_mode=["updates", "messages", "custom"], subgraphs=True
+            ):
+                await queue.put(event)
+        finally:
+            await queue.put(_STREAM_SENTINEL)
+
+    producer_task = asyncio.create_task(_producer())
+    try:
+        while True:
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=interval)
+            except asyncio.TimeoutError:
+                yield _SSE_PING
+                continue
+            if item is _STREAM_SENTINEL:
+                break
+            yield item
+    finally:
+        producer_task.cancel()
+        try:
+            await producer_task
+        except asyncio.CancelledError:
+            pass
+
+
 async def message_generator(
     user_input: StreamInput, agent_id: str = DEFAULT_AGENT
 ) -> AsyncGenerator[str, None]:
@@ -221,15 +268,21 @@ async def message_generator(
     Generate a stream of messages from the agent.
 
     This is the workhorse method for the /stream endpoint.
+
+    A keep-alive SSE comment (`: ping`) is sent every KEEP_ALIVE_INTERVAL seconds
+    while the agent is busy (e.g. running a long tool call) so that proxies and
+    clients do not close the connection due to network idle timeouts.
     """
     agent: AgentGraph = get_agent(agent_id)
     kwargs, run_id = await _handle_input(user_input, agent)
 
     try:
         # Process streamed events from the graph and yield messages over the SSE stream.
-        async for stream_event in agent.astream(
-            **kwargs, stream_mode=["updates", "messages", "custom"], subgraphs=True
-        ):
+        async for stream_event in _agent_stream_with_keepalive(agent, kwargs, _KEEP_ALIVE_INTERVAL):
+            # Pass keep-alive pings directly to the client and skip normal processing
+            if stream_event is _SSE_PING:
+                yield _SSE_PING
+                continue
             if not isinstance(stream_event, tuple):
                 continue
             # Handle different stream event structures based on subgraphs


### PR DESCRIPTION
## Summary

Fixes #126 — when an agent runs a long tool call (e.g. >60 seconds), proxies and load balancers close the idle SSE connection before the agent responds, causing the client to see a dropped connection with no response.

## Root Cause

The `/stream` endpoint is a server-sent events (SSE) connection. During a long tool call, the agent produces no output for an extended period. Many network proxies (nginx, AWS ALB, Cloudflare) have default idle timeouts of 60s and will silently kill connections that carry no data.

## Fix

A background `asyncio` producer task feeds all agent stream events into a queue. The main generator reads from the queue with a **15-second timeout**. If nothing arrives in time, it yields an SSE comment line (`: ping\n\n`) to keep the connection alive, then resumes waiting.

```
Producer (background)          Consumer (SSE loop)
─────────────────────          ───────────────────
agent.astream() running  →  queue.get(timeout=15s)
                                   │
                         timeout? → yield ": ping"
                         event?  → process normally
                         SENTINEL → stop
```

## Why a queue and not asyncio.wait_for on the iterator directly?

`asyncio.wait_for` cancels the awaitable on timeout. When applied directly to `__anext__()`, this cancels the generator's internal coroutine and permanently breaks it — subsequent iterations raise `StopAsyncIteration` immediately. The queue approach keeps the agent generator completely undisturbed; only the queue read has a timeout.

## Cleanup on disconnect

When the user switches chat or closes the tab, the browser closes the SSE connection. FastAPI cancels the generator, which triggers the `finally` block that cancels the producer task. No orphaned tasks or memory leaks.

## Client-side impact

The SSE comment format (`: ping\n\n`) is defined in the SSE spec as a no-op. Browsers ignore it natively. The `httpx`-based `AgentClient` already only processes lines starting with `data:`, so ping lines pass through silently with no code changes needed on the client side.

## Test plan

- [ ] Trigger a long-running tool call (>60s) and confirm the connection stays open
- [ ] Confirm the client receives the final response correctly after the tool finishes  
- [ ] Switch chat mid-stream and confirm no orphaned tasks remain on the server
- [ ] Short tool calls (<15s) are unaffected — no pings sent, no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
