### PR TITLE
fix: warn at startup when AUTH_SECRET is not configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ COMPATIBLE_BASE_URL=
 HOST=0.0.0.0
 PORT=8080
 
-# Authentication secret, HTTP bearer token header is required if set
+# Authentication secret, HTTP bearer token header is required if set.
+# WARNING: If unset, all API endpoints are unauthenticated. Always set this in production.
 AUTH_SECRET=
 
 # Langsmith configuration

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -79,6 +79,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             if hasattr(store, "setup"):  # ignore: union-attr
                 await store.setup()
 
+            if not settings.AUTH_SECRET:
+                logger.warning(
+                    "AUTH_SECRET is not configured — all API endpoints are unauthenticated. "
+                    "Set AUTH_SECRET in your environment to enable bearer token authentication."
+                )
+
             # Configure agents with both memory components and async loading
             agents = get_all_agent_info()
             for a in agents:


### PR DESCRIPTION
## Problem

When `AUTH_SECRET` is not set, `verify_bearer()` in `src/service/service.py` returns immediately without checking credentials, leaving all API endpoints (`/invoke`, `/stream`, `/history`, `/feedback`, `/info`) open to unauthenticated access. This is documented as intentional for development, but it is easy to deploy to production without realising the service is running in this mode — `.env.example` ships with `AUTH_SECRET=` (empty), and there is no warning in the logs or on startup.

## Fix

Add a `WARNING`-level log message in `lifespan()` that fires at startup when `AUTH_SECRET` is `None`. Also add a comment to `.env.example` making the production implication explicit.

No behavior change. The existing opt-in/opt-out design is preserved — the only difference is that the open state is now logged rather than silent.

## Diff

```diff
diff --git a/.env.example b/.env.example
index d00799f..1e46f76 100644
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ COMPATIBLE_BASE_URL=
 HOST=0.0.0.0
 PORT=8080
 
-# Authentication secret, HTTP bearer token header is required if set
+# Authentication secret, HTTP bearer token header is required if set.
+# WARNING: If unset, all API endpoints are unauthenticated. Always set this in production.
 AUTH_SECRET=
 
diff --git a/src/service/service.py b/src/service/service.py
index 4dce719..cd60256 100644
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -79,6 +79,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             if hasattr(store, "setup"):  # ignore: union-attr
                 await store.setup()
 
+            if not settings.AUTH_SECRET:
+                logger.warning(
+                    "AUTH_SECRET is not configured — all API endpoints are unauthenticated. "
+                    "Set AUTH_SECRET in your environment to enable bearer token authentication."
+                )
+
             # Configure agents with both memory components and async loading
```

## Test plan

- [x] Service starts normally when `AUTH_SECRET` is set — no warning emitted
- [x] Service starts and logs `WARNING: AUTH_SECRET is not configured...` when `AUTH_SECRET` is unset
- [x] Existing test suite: `test_auth.py::test_no_auth_secret` continues to pass (behavior unchanged)
- [x] Manually verified warning appears in `docker compose up` output when `AUTH_SECRET=` is left empty in `.env`

> ⚠️ No CI is configured on the fork. The fix was validated by running the auth-related test cases and confirming the warning message is emitted via a standalone Python test against the patched `lifespan()` logic.