### PR TITLE
Fix test suite warnings

### DIFF
--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -2,7 +2,7 @@ from functools import cache
 
 from langchain_anthropic import ChatAnthropic
 from langchain_aws import ChatBedrock
-from langchain_community.chat_models import FakeListChatModel
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_google_vertexai import ChatVertexAI
 from langchain_groq import ChatGroq

--- a/tests/agents/test_lazy_agent.py
+++ b/tests/agents/test_lazy_agent.py
@@ -7,7 +7,7 @@ import pytest
 from agents.lazy_agent import LazyLoadingAgent
 
 
-class TestLazyLoadingAgent(LazyLoadingAgent):
+class LazyLoadingAgentFixture(LazyLoadingAgent):
     """Test implementation of LazyLoadingAgent."""
 
     def __init__(self):
@@ -29,26 +29,26 @@ class TestLazyLoadingAgentBase:
 
     def test_initialization(self):
         """Test that agent initializes correctly."""
-        agent = TestLazyLoadingAgent()
+        agent = LazyLoadingAgentFixture()
         assert not agent._loaded
         assert agent._graph is None
 
     @pytest.mark.asyncio
     async def test_load(self):
         """Test that load works correctly."""
-        agent = TestLazyLoadingAgent()
+        agent = LazyLoadingAgentFixture()
         await agent.load()
         assert agent._loaded
 
     def test_get_graph_before_load(self):
         """Test that get_graph raises error before load."""
-        agent = TestLazyLoadingAgent()
+        agent = LazyLoadingAgentFixture()
         with pytest.raises(RuntimeError, match="Agent not loaded"):
             agent.get_graph()
 
     def test_get_graph_after_load(self):
         """Test that get_graph works after load."""
-        agent = TestLazyLoadingAgent()
+        agent = LazyLoadingAgentFixture()
         agent._loaded = True
         agent._graph = Mock()
 
@@ -57,7 +57,7 @@ class TestLazyLoadingAgentBase:
 
     def test_get_graph_no_graph_created(self):
         """Test that get_graph raises error if no graph was created."""
-        agent = TestLazyLoadingAgent()
+        agent = LazyLoadingAgentFixture()
         agent._loaded = True
         agent._graph = None
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -196,6 +196,7 @@ async def test_astream(agent_client):
     mock_response = AsyncMock()
     mock_response.status_code = 200
     mock_response.request = Request("POST", "http://test/stream")
+    mock_response.raise_for_status = Mock()
     mock_response.aiter_lines = Mock(return_value=async_events())
     mock_response.__aenter__ = AsyncMock(return_value=mock_response)
 

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from langchain_anthropic import ChatAnthropic
-from langchain_community.chat_models import FakeListChatModel
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_groq import ChatGroq
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI

--- a/tests/service/test_service.py
+++ b/tests/service/test_service.py
@@ -4,8 +4,7 @@ from unittest.mock import AsyncMock, patch
 import langsmith
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
-from langgraph.pregel.types import StateSnapshot
-from langgraph.types import Interrupt
+from langgraph.types import Interrupt, StateSnapshot
 
 from agents.agents import Agent
 from schema import ChatHistory, ChatMessage, ServiceMetadata


### PR DESCRIPTION
## Summary
- Switch `FakeListChatModel` import from the deprecated `langchain-community` package to `langchain-core` (`src/core/llm.py`, `tests/core/test_llm.py`)
- Rename the `TestLazyLoadingAgent` test fixture to `LazyLoadingAgentFixture` so pytest stops trying (and failing) to collect it as a test class, since it defines an `__init__`
- Use the non-deprecated `langgraph.types` import for `StateSnapshot` instead of `langgraph.pregel.types`
- Fix a `RuntimeWarning: coroutine ... was never awaited` in `test_astream`: the mocked `raise_for_status` was an `AsyncMock` attribute returning an unawaited coroutine, since real `httpx.Response.raise_for_status()` is synchronous

Reduces test suite warnings from 11 down to 8. The remaining warnings originate from third-party libraries (`langgraph_supervisor`, `starlette`/`fastapi` testclient internals) or require a behavior change to production code (`AgentClient`'s `timeout` handling) rather than being local, low-risk fixes.

## Test plan
- [x] `uv run pytest` — 126 passed, 2 skipped, no regressions
- [x] `uv run ruff check` and `uv run ruff format --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yNqzrqWDHSC2onj88T3D7

---
_Generated by [Claude Code](https://claude.ai/code/session_017yNqzrqWDHSC2onj88T3D7)_