### PR TITLE
ci: bump azure/webapps-deploy action to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: Deploy to Azure Web App
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: 'agent-service'
           slot-name: 'production'


### PR DESCRIPTION
## Summary
- Bump `azure/webapps-deploy` from `@v2` to `@v3` in `.github/workflows/deploy.yml`
- v3 supports the same `images` + `publish-profile` container deployment inputs used here, so no other changes are needed

## Test plan
- [ ] Deploy workflow runs successfully on merge to `main`


---
_Generated by [Claude Code](https://claude.ai/code/session_012eGvwzYVHhLpfr2rPhLf3R)_