### PR TITLE
Add AG-UI protocol support for agent service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,7 @@ cython_debug/
 # Private Credentials, ignore everything in the folder but the .gitkeep file
 privatecredentials/*
 !privatecredentials/.gitkeep
+
+# Node (scripts/agui-client)
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ docker compose watch
 1. **LangGraph Agent and latest features**: A customizable agent built using the LangGraph framework. Implements the latest LangGraph v1.0 features including human in the loop with `interrupt()`, flow control with `Command`, long-term memory with `Store`, and `langgraph-supervisor`.
 1. **FastAPI Service**: Serves the agent with both streaming and non-streaming endpoints.
 1. **Advanced Streaming**: A novel approach to support both token-based and message-based streaming.
+1. **AG-UI Protocol Support**: Every agent is also served over the [AG-UI protocol](https://docs.ag-ui.com) for connecting AG-UI compatible frontends like CopilotKit - see [docs](docs/AGUI.md).
 1. **Streamlit Interface**: Provides a user-friendly chat interface for interacting with the agent, including voice input and output.
 1. **Multiple Agent Support**: Run multiple agents in the service and call by URL path. Available agents and models are described in `/info`
 1. **Asynchronous Design**: Utilizes async/await for efficient handling of concurrent requests.

--- a/docs/AGUI.md
+++ b/docs/AGUI.md
@@ -1,0 +1,86 @@
+# AG-UI Protocol Support
+
+The service exposes every agent over the [AG-UI protocol](https://docs.ag-ui.com) — an open,
+event-based standard for connecting agents to user-facing applications, used by
+[CopilotKit](https://docs.copilotkit.ai) and a growing set of frameworks. This lets you build a
+production React/Next.js frontend for your agents while keeping the Streamlit app for development.
+
+The heavy lifting (translating LangGraph execution into AG-UI events) is done by the official
+[`ag-ui-langgraph`](https://pypi.org/project/ag-ui-langgraph/) package. The service adds a thin
+adapter (`src/service/agui.py`) that wires it into the agent registry, bearer auth, and Langfuse
+tracing.
+
+## Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /agui/{agent_id}/run` | Run an agent, streaming AG-UI events over SSE |
+| `POST /agui/run` | Same, using the default agent |
+
+The request body is the standard AG-UI `RunAgentInput`. The same `AUTH_SECRET` bearer auth as the
+rest of the API applies.
+
+## Connecting a frontend
+
+The expected production setup is the standard CopilotKit architecture: your frontend talks to a
+[CopilotKit runtime](https://docs.copilotkit.ai) (e.g. a Next.js API route), which connects to
+this service server-side using the AG-UI `HttpAgent`:
+
+```ts
+import { HttpAgent } from "@ag-ui/client";
+
+const agent = new HttpAgent({
+  url: "http://your-service:8080/agui/research-assistant/run",
+  headers: { Authorization: `Bearer ${process.env.AUTH_SECRET}` },
+});
+```
+
+The runtime holds the bearer token and acts as the trusted layer between browsers and the agent
+service, the same role the Streamlit app plays for the vanilla API. Direct browser access to the
+endpoint is possible for experiments, but you'd need to add CORS middleware to the service
+yourself and your `AUTH_SECRET` would be visible to browsers — prefer the runtime pattern.
+
+## Trying it out
+
+A minimal reference client using the official SDK is included:
+
+```sh
+# start the service in one shell (or docker compose watch)
+python src/run_service.py
+
+# in another shell
+cd scripts/agui-client
+npm install
+node client.mjs "Tell me a joke!" chatbot
+```
+
+Use `THREAD_ID` to continue a conversation, and `AUTH_SECRET` / `AGENT_URL` as needed:
+
+```sh
+THREAD_ID=my-thread node client.mjs "And another one" chatbot
+```
+
+## Behavior notes
+
+- **Threads are shared with the vanilla API.** Both protocols use the same checkpointer keyed by
+  thread ID, so a conversation started on `/stream` can be continued over AG-UI and vice versa.
+  One caveat: messages are deduplicated by ID, so don't replay past messages with newly generated
+  IDs (well-behaved AG-UI clients preserve IDs and are fine).
+- **Per-request configuration** goes in `forwardedProps.configurable` — the AG-UI equivalent of
+  the vanilla API's `model` / `user_id` / `agent_config` fields, e.g.
+  `{"forwardedProps": {"configurable": {"model": "gpt-5.2"}}}`. Keys managed by the protocol
+  (`thread_id`, `checkpoint_id`, `checkpoint_ns`) are rejected.
+- **Interrupts** (human-in-the-loop) surface as a `CUSTOM` event named `on_interrupt`. Resume by
+  running the same thread again with `{"forwardedProps": {"command": {"resume": <answer>}}}`.
+- **Graph state is client-visible.** AG-UI's shared-state feature sends `STATE_SNAPSHOT` events
+  containing the full graph state, so don't put secrets or internal-only data in agent state.
+- **`RAW` passthrough events are filtered out** by the adapter. Standard AG-UI clients ignore
+  them, and they would expose server-side internals (including fully rendered prompts) to
+  callers. If you need the full event firehose for debugging (e.g. the AG-UI Event Inspector)
+  behind a trusted layer, remove the filter in `src/service/agui.py`.
+- **`/feedback` and `/history` are not bridged.** The AG-UI `runId` is client-generated and isn't
+  used as the LangSmith run ID, so star feedback doesn't apply to AG-UI runs. AG-UI clients
+  manage their own message history from the event stream.
+- The `ag-ui-langgraph` package is pre-1.0 and pinned accordingly. If a future LangGraph major
+  release ever conflicts with it, the integration should be dropped or lag behind rather than
+  hold back core upgrades.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,4 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["ag_ui_langgraph.*"]
-ignore_missing_imports = true
+follow_untyped_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "uvicorn ~=0.49.0",
     "langchain-mcp-adapters>=0.3.0",
     "ddgs>=9.14.4",
+    "ag-ui-langgraph~=0.0.42",
 ]
 
 [dependency-groups]
@@ -105,4 +106,8 @@ follow_untyped_imports = true
 
 [[tool.mypy.overrides]]
 module = ["langchain_mcp_adapters.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["ag_ui_langgraph.*"]
 ignore_missing_imports = true

--- a/scripts/agui-client/client.mjs
+++ b/scripts/agui-client/client.mjs
@@ -33,6 +33,7 @@ console.log(`user: ${message}\n`);
 agent.messages = [{ id: randomUUID(), role: "user", content: message }];
 
 const eventTypes = new Set();
+let printedPrefix = false;
 try {
   await agent.runAgent(
     { runId: randomUUID() },
@@ -40,8 +41,15 @@ try {
       onEvent({ event }) {
         eventTypes.add(event.type);
       },
-      onTextMessageContentEvent({ textMessageBuffer }) {
-        process.stdout.write(`\rassistant: ${textMessageBuffer}`);
+      onTextMessageContentEvent({ event }) {
+        // Print each delta as it arrives rather than re-rendering the full buffer -
+        // an in-place overwrite via \r depends on terminal support that isn't
+        // consistent (e.g. piping through `docker compose logs`).
+        if (!printedPrefix) {
+          process.stdout.write("assistant: ");
+          printedPrefix = true;
+        }
+        process.stdout.write(event.delta);
       },
       onCustomEvent({ event }) {
         if (event.name === "on_interrupt") {

--- a/scripts/agui-client/client.mjs
+++ b/scripts/agui-client/client.mjs
@@ -1,0 +1,65 @@
+// Minimal AG-UI client for manually validating the service's /agui endpoints,
+// built on the official @ag-ui/client SDK. See docs/AGUI.md for details.
+//
+// Usage:
+//   cd scripts/agui-client
+//   npm install
+//   node client.mjs [message] [agent]
+//
+// Environment variables:
+//   AGENT_URL   - base URL of the agent service (default: http://localhost:8080)
+//   AUTH_SECRET - bearer token, if the service has one configured
+//   THREAD_ID   - reuse a thread to continue a conversation (default: random)
+
+import { randomUUID } from "crypto";
+import { HttpAgent } from "@ag-ui/client";
+
+const message = process.argv[2] ?? "Tell me a joke!";
+const agentId = process.argv[3] ?? "chatbot";
+const baseUrl = process.env.AGENT_URL ?? "http://localhost:8080";
+const threadId = process.env.THREAD_ID ?? randomUUID();
+
+const agent = new HttpAgent({
+  url: `${baseUrl}/agui/${agentId}/run`,
+  threadId,
+  headers: process.env.AUTH_SECRET
+    ? { Authorization: `Bearer ${process.env.AUTH_SECRET}` }
+    : {},
+});
+
+console.log(`agent: ${agentId}  thread: ${threadId}`);
+console.log(`user: ${message}\n`);
+
+agent.messages = [{ id: randomUUID(), role: "user", content: message }];
+
+const eventTypes = new Set();
+try {
+  await agent.runAgent(
+    { runId: randomUUID() },
+    {
+      onEvent({ event }) {
+        eventTypes.add(event.type);
+      },
+      onTextMessageContentEvent({ textMessageBuffer }) {
+        process.stdout.write(`\rassistant: ${textMessageBuffer}`);
+      },
+      onCustomEvent({ event }) {
+        if (event.name === "on_interrupt") {
+          console.log(`[interrupted] ${JSON.stringify(event.value)}`);
+          console.log(
+            "resume by running the same thread with forwardedProps {command: {resume: <answer>}} - see docs/AGUI.md"
+          );
+        }
+      },
+    }
+  );
+} catch (err) {
+  console.error(`\nrun failed: ${err.message ?? err}`);
+  if (String(err.message).includes("401")) {
+    console.error("hint: set AUTH_SECRET to the service's bearer token");
+  }
+  process.exit(1);
+}
+
+console.log(`\n\nevent types received: ${[...eventTypes].join(", ")}`);
+console.log(`continue this thread with: THREAD_ID=${threadId} node client.mjs '<message>' ${agentId}`);

--- a/scripts/agui-client/package.json
+++ b/scripts/agui-client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "agui-client-example",
+  "private": true,
+  "type": "module",
+  "description": "Minimal AG-UI client for manually validating the agent service's /agui endpoints",
+  "dependencies": {
+    "@ag-ui/client": "^0.0.57"
+  }
+}

--- a/src/service/agui.py
+++ b/src/service/agui.py
@@ -1,0 +1,103 @@
+"""AG-UI protocol endpoint for the agent service.
+
+Exposes any agent in the service over the AG-UI protocol (https://docs.ag-ui.com)
+so it can be used with AG-UI compatible frontends like CopilotKit. The
+LangGraph -> AG-UI event translation is handled by the official `ag-ui-langgraph`
+package; this module only wires it into the service's agent registry, auth, and
+tracing.
+
+See docs/AGUI.md for usage, including how to connect a client.
+"""
+
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from ag_ui.core import EventType, RunAgentInput
+from ag_ui.encoder import EventEncoder
+from ag_ui_langgraph import LangGraphAgent
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import StreamingResponse
+from langchain_core.runnables import RunnableConfig
+from langfuse.langchain import CallbackHandler  # type: ignore[import-untyped]
+
+from agents import DEFAULT_AGENT, AgentGraph, get_agent
+from core import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/agui")
+
+# Managed by the protocol (thread_id comes from RunAgentInput) or the checkpointer,
+# so clients may not override them via forwardedProps.configurable.
+RESERVED_CONFIGURABLE_KEYS = {"thread_id", "checkpoint_id", "checkpoint_ns"}
+
+
+def _base_config(input_data: RunAgentInput) -> RunnableConfig:
+    """Build the base RunnableConfig for an AG-UI run.
+
+    Clients can pass configurable values (e.g. `model`, `user_id`, or custom agent
+    config) in `forwardedProps.configurable` - the AG-UI equivalent of the vanilla
+    API's `model` / `user_id` / `agent_config` fields. `thread_id` is taken from
+    the AG-UI input by the `ag-ui-langgraph` package itself.
+    """
+    forwarded: dict[str, Any] = input_data.forwarded_props or {}
+    configurable = forwarded.get("configurable") or {}
+    if not isinstance(configurable, dict):
+        raise HTTPException(status_code=422, detail="forwardedProps.configurable must be an object")
+    if overlap := RESERVED_CONFIGURABLE_KEYS & configurable.keys():
+        raise HTTPException(
+            status_code=422,
+            detail=f"forwardedProps.configurable contains reserved keys: {overlap}",
+        )
+
+    callbacks: list[Any] = []
+    if settings.LANGFUSE_TRACING:
+        callbacks.append(CallbackHandler())
+
+    return RunnableConfig(configurable=dict(configurable), callbacks=callbacks)
+
+
+async def _event_stream(
+    agent_id: str,
+    graph: AgentGraph,
+    input_data: RunAgentInput,
+    config: RunnableConfig,
+    encoder: EventEncoder,
+) -> AsyncGenerator[str, None]:
+    # A new LangGraphAgent per request: it holds per-run state and is cheap to build.
+    agent = LangGraphAgent(name=agent_id, graph=graph, config=config)  # type: ignore[arg-type]
+    async for event in agent.run(input_data):
+        # Don't forward RAW passthrough events. Standard AG-UI clients ignore them,
+        # and they expose server-side internals - including fully rendered prompts
+        # from on_chat_model_start - to the caller. Remove this filter only if the
+        # endpoint is consumed by a trusted middle layer and you want the full
+        # event firehose (e.g. for the AG-UI Event Inspector).
+        if event.type == EventType.RAW:
+            continue
+        yield encoder.encode(event)
+
+
+@router.post("/run", operation_id="agui_run_default")
+@router.post("/{agent_id}/run", operation_id="agui_run")
+async def agui_run(
+    input_data: RunAgentInput, request: Request, agent_id: str = DEFAULT_AGENT
+) -> StreamingResponse:
+    """
+    Run an agent over the AG-UI protocol, streaming AG-UI events via SSE.
+
+    Point an AG-UI client (e.g. CopilotKit's runtime or HttpAgent) at this endpoint.
+    Use the same threadId across runs to continue a conversation - threads are
+    persisted in the service's checkpointer and shared with the vanilla API.
+    """
+    try:
+        graph: AgentGraph = get_agent(agent_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
+
+    config = _base_config(input_data)
+    encoder = EventEncoder(accept=request.headers.get("accept", ""))
+    return StreamingResponse(
+        _event_stream(agent_id, graph, input_data, config, encoder),
+        media_type=encoder.get_content_type(),
+    )

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -35,6 +35,7 @@ from schema import (
     StreamInput,
     UserInput,
 )
+from service.agui import router as agui_router
 from service.utils import (
     convert_message_content_to_string,
     langchain_to_chat_message,
@@ -108,6 +109,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(lifespan=lifespan, generate_unique_id_function=custom_generate_unique_id)
 router = APIRouter(dependencies=[Depends(verify_bearer)])
+# AG-UI protocol endpoints inherit the same bearer auth - see service/agui.py
+router.include_router(agui_router)
 
 
 @router.get("/info")

--- a/tests/service/test_agui.py
+++ b/tests/service/test_agui.py
@@ -1,0 +1,193 @@
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from ag_ui.core.events import Event
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, MessagesState, StateGraph
+from langgraph.types import interrupt
+from pydantic import TypeAdapter
+
+FAKE_RESPONSE = "The answer is 42"
+
+event_adapter: TypeAdapter[Event] = TypeAdapter(Event)
+
+# Captures the configurable seen by the agent, for the forwardedProps test
+captured_configurable: dict[str, Any] = {}
+
+
+async def call_model(state: MessagesState, config: RunnableConfig) -> MessagesState:
+    captured_configurable.update(config["configurable"])
+    model = FakeListChatModel(responses=[FAKE_RESPONSE])
+    response = await model.ainvoke(state["messages"])
+    return {"messages": [response]}
+
+
+model_graph = StateGraph(MessagesState)
+model_graph.add_node("model", call_model)
+model_graph.set_entry_point("model")
+model_graph.add_edge("model", END)
+model_agent = model_graph.compile(checkpointer=MemorySaver())
+
+
+async def ask_color(state: MessagesState) -> MessagesState:
+    answer = interrupt("What is your favorite color?")
+    return {"messages": [AIMessage(content=f"Your favorite color is {answer}")]}
+
+
+interrupt_graph = StateGraph(MessagesState)
+interrupt_graph.add_node("ask", ask_color)
+interrupt_graph.set_entry_point("ask")
+interrupt_graph.add_edge("ask", END)
+interrupt_agent = interrupt_graph.compile(checkpointer=MemorySaver())
+
+
+@pytest.fixture
+def mock_agui_agent():
+    def agent_lookup(agent_id: str):
+        agents = {"model-agent": model_agent, "interrupt-agent": interrupt_agent}
+        try:
+            return agents[agent_id]
+        except KeyError:
+            raise KeyError(agent_id)
+
+    with patch("service.agui.get_agent", side_effect=agent_lookup):
+        yield
+
+
+def run_input(thread_id: str = "test-thread", **overrides: Any) -> dict[str, Any]:
+    body = {
+        "threadId": thread_id,
+        "runId": "test-run",
+        "messages": [{"id": "msg-1", "role": "user", "content": "Hello"}],
+        "tools": [],
+        "context": [],
+        "state": {},
+        "forwardedProps": {},
+    }
+    body.update(overrides)
+    return body
+
+
+def collect_events(test_client, path: str, body: dict[str, Any]) -> list[dict[str, Any]]:
+    """POST to an AG-UI endpoint and parse the SSE response into event dicts."""
+    with test_client.stream("POST", path, json=body) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        events = []
+        for line in response.iter_lines():
+            if line.startswith("data: "):
+                events.append(json.loads(line[len("data: ") :]))
+        return events
+
+
+def test_agui_stream_lifecycle(mock_agui_agent, test_client) -> None:
+    """A basic run emits a protocol-conformant AG-UI event stream."""
+    events = collect_events(test_client, "/agui/model-agent/run", run_input())
+
+    # Every event must parse as a valid AG-UI event (protocol conformance).
+    for event in events:
+        event_adapter.validate_python(event)
+
+    types = [e["type"] for e in events]
+    assert types[0] == "RUN_STARTED"
+    assert types[-1] == "RUN_FINISHED"
+
+    # Tokens assemble into the model response
+    text = "".join(e["delta"] for e in events if e["type"] == "TEXT_MESSAGE_CONTENT")
+    assert text == FAKE_RESPONSE
+
+    # The final messages snapshot includes the exchange
+    snapshots = [e for e in events if e["type"] == "MESSAGES_SNAPSHOT"]
+    assert snapshots
+    roles = [(m["role"], m.get("content")) for m in snapshots[-1]["messages"]]
+    assert ("user", "Hello") in roles
+    assert ("assistant", FAKE_RESPONSE) in roles
+
+
+def test_agui_no_raw_events(mock_agui_agent, test_client) -> None:
+    """RAW passthrough events are filtered out - they expose server-side internals."""
+    events = collect_events(test_client, "/agui/model-agent/run", run_input())
+    assert all(e["type"] != "RAW" for e in events)
+
+
+def test_agui_default_agent_route(mock_agui_agent, test_client) -> None:
+    """POST /agui/run falls back to the default agent."""
+    with patch("service.agui.get_agent", return_value=model_agent) as mock_get_agent:
+        events = collect_events(test_client, "/agui/run", run_input())
+    from agents import DEFAULT_AGENT
+
+    mock_get_agent.assert_called_once_with(DEFAULT_AGENT)
+    assert events[-1]["type"] == "RUN_FINISHED"
+
+
+def test_agui_unknown_agent(mock_agui_agent, test_client) -> None:
+    response = test_client.post("/agui/no-such-agent/run", json=run_input())
+    assert response.status_code == 404
+
+
+def test_agui_configurable_passthrough(mock_agui_agent, test_client) -> None:
+    """forwardedProps.configurable values reach the agent's configurable."""
+    captured_configurable.clear()
+    body = run_input(forwardedProps={"configurable": {"model": "fake", "user_id": "user-123"}})
+    collect_events(test_client, "/agui/model-agent/run", body)
+    assert captured_configurable.get("model") == "fake"
+    assert captured_configurable.get("user_id") == "user-123"
+
+
+def test_agui_configurable_reserved_keys(mock_agui_agent, test_client) -> None:
+    body = run_input(forwardedProps={"configurable": {"thread_id": "hijack"}})
+    response = test_client.post("/agui/model-agent/run", json=body)
+    assert response.status_code == 422
+    assert "reserved" in response.json()["detail"]
+
+
+def test_agui_configurable_wrong_type(mock_agui_agent, test_client) -> None:
+    body = run_input(forwardedProps={"configurable": "not-a-dict"})
+    response = test_client.post("/agui/model-agent/run", json=body)
+    assert response.status_code == 422
+
+
+def test_agui_interrupt_and_resume(mock_agui_agent, test_client) -> None:
+    """An interrupt surfaces as an on_interrupt CUSTOM event and can be resumed."""
+    thread_id = "interrupt-thread"
+    events = collect_events(test_client, "/agui/interrupt-agent/run", run_input(thread_id))
+    assert events[-1]["type"] == "RUN_FINISHED"
+    interrupts = [e for e in events if e["type"] == "CUSTOM" and e["name"] == "on_interrupt"]
+    assert len(interrupts) == 1
+    assert interrupts[0]["value"] == "What is your favorite color?"
+
+    # Resume the run with an answer
+    resume_body = run_input(thread_id, messages=[], forwardedProps={"command": {"resume": "blue"}})
+    events = collect_events(test_client, "/agui/interrupt-agent/run", resume_body)
+    assert events[-1]["type"] == "RUN_FINISHED"
+    snapshots = [e for e in events if e["type"] == "MESSAGES_SNAPSHOT"]
+    contents = [m.get("content") for m in snapshots[-1]["messages"]]
+    assert "Your favorite color is blue" in contents
+
+
+def test_agui_auth(mock_settings, mock_agui_agent, test_client) -> None:
+    """The AG-UI endpoints enforce the same bearer auth as the rest of the service."""
+    from pydantic import SecretStr
+
+    mock_settings.AUTH_SECRET = SecretStr("test-secret")
+    response = test_client.post("/agui/model-agent/run", json=run_input())
+    assert response.status_code == 401
+
+    response = test_client.post(
+        "/agui/model-agent/run",
+        json=run_input(),
+        headers={"Authorization": "Bearer wrong-secret"},
+    )
+    assert response.status_code == 401
+
+    response = test_client.post(
+        "/agui/model-agent/run",
+        json=run_input(),
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert response.status_code == 200

--- a/tests/service/test_agui.py
+++ b/tests/service/test_agui.py
@@ -46,6 +46,13 @@ interrupt_graph.add_edge("ask", END)
 interrupt_agent = interrupt_graph.compile(checkpointer=MemorySaver())
 
 
+@pytest.fixture(autouse=True)
+def _reset_captured_configurable():
+    """Every test using model_agent writes to this shared dict; reset before each test."""
+    captured_configurable.clear()
+    yield
+
+
 @pytest.fixture
 def mock_agui_agent():
     def agent_lookup(agent_id: str):
@@ -132,7 +139,6 @@ def test_agui_unknown_agent(mock_agui_agent, test_client) -> None:
 
 def test_agui_configurable_passthrough(mock_agui_agent, test_client) -> None:
     """forwardedProps.configurable values reach the agent's configurable."""
-    captured_configurable.clear()
     body = run_input(forwardedProps={"configurable": {"model": "fake", "user_id": "user-123"}})
     collect_events(test_client, "/agui/model-agent/run", body)
     assert captured_configurable.get("model") == "fake"

--- a/uv.lock
+++ b/uv.lock
@@ -14,10 +14,49 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ag-ui-a2ui-toolkit"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ce/85f3960a83d962e5690bc0f27a3baf3bf1602edc2b0603085928c964ea14/ag_ui_a2ui_toolkit-0.0.4.tar.gz", hash = "sha256:172e2724e53df8173685a3fb896a6e5175eea06e1dc166c715db110ba4beba76", size = 18960, upload-time = "2026-06-17T13:34:28.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/7a/acf85b01cd996bd011b71e181fd9f3daff5396fc3b7d78ba9445bfc08ecf/ag_ui_a2ui_toolkit-0.0.4-py3-none-any.whl", hash = "sha256:236fc511e1ec2399bcda0c14a109b3fb0a0c3e3988c18ef1918745b1c1535e30", size = 21315, upload-time = "2026-06-17T13:34:29.505Z" },
+]
+
+[[package]]
+name = "ag-ui-langgraph"
+version = "0.0.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ag-ui-a2ui-toolkit" },
+    { name = "ag-ui-protocol" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d5/648338b5ff8f90c488217297a8656b6c133a251a39af2d62bada142b7819/ag_ui_langgraph-0.0.42.tar.gz", hash = "sha256:5384647b9b7b098189530c59b26741581dd009c8dfda907fbfaa9bafa8d21249", size = 330419, upload-time = "2026-06-19T15:07:01.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c0/32fea8de7ac50a90ea150f999318f4d121cd22d58e446c8fdb420fc2a11e/ag_ui_langgraph-0.0.42-py3-none-any.whl", hash = "sha256:4fd19f0da6d0e16d727ec89e99b692916cbba2b0302f96aba2497043cbfec5db", size = 37969, upload-time = "2026-06-19T15:07:00.517Z" },
+]
+
+[[package]]
+name = "ag-ui-protocol"
+version = "0.1.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/10/4ad299267a7d04b89935aa99eef62979758fcf95aee9f8bb5d70c35b1be1/ag_ui_protocol-0.1.19.tar.gz", hash = "sha256:43c27f60d41712dcad0e9e0a203cbdf1c8e248b22417374c5c68321c448af4ea", size = 10720, upload-time = "2026-06-02T17:26:15.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/0a/bcad8116eb058e4b4a305e3fc37ebd7efc879deeb86b854f1c5b8b6e97dd/ag_ui_protocol-0.1.19-py3-none-any.whl", hash = "sha256:898843b1410d378824da0c6a776486288b9c5828689d0bf563118868e37f390f", size = 13490, upload-time = "2026-06-02T17:26:16.313Z" },
+]
+
+[[package]]
 name = "agent-service-toolkit"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "ag-ui-langgraph" },
     { name = "aiosqlite" },
     { name = "ddgs" },
     { name = "docx2txt" },
@@ -81,6 +120,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-langgraph", specifier = "~=0.0.42" },
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "ddgs", specifier = ">=9.14.4" },
     { name = "docx2txt", specifier = "~=0.8" },


### PR DESCRIPTION
## Summary
Adds support for the AG-UI protocol to expose agents over a standardized event-based interface, enabling integration with AG-UI-compatible frontends like CopilotKit while maintaining compatibility with the existing vanilla API.

## Key Changes

- **New AG-UI endpoint** (`src/service/agui.py`): Implements `/agui/{agent_id}/run` and `/agui/run` endpoints that stream AG-UI events via SSE. Uses the official `ag-ui-langgraph` package to translate LangGraph execution into AG-UI events.

- **Configuration and validation**: 
  - Supports per-request configuration via `forwardedProps.configurable` (AG-UI equivalent of vanilla API's `model`/`user_id`/`agent_config`)
  - Validates and rejects reserved configurable keys (`thread_id`, `checkpoint_id`, `checkpoint_ns`)
  - Integrates with existing bearer token authentication and Langfuse tracing

- **Event filtering**: Filters out `RAW` passthrough events to prevent exposure of server-side internals (e.g., fully rendered prompts)

- **Thread persistence**: Shares the same checkpointer with the vanilla API, allowing conversations to be continued across both protocols using the same thread ID

- **Comprehensive test suite** (`tests/service/test_agui.py`): 
  - Protocol conformance validation
  - Event stream lifecycle testing
  - Configuration passthrough and validation
  - Interrupt/resume functionality
  - Bearer token authentication
  - Unknown agent handling

- **Reference client** (`scripts/agui-client/`): Minimal Node.js example client using the official `@ag-ui/client` SDK for manual validation

- **Documentation** (`docs/AGUI.md`): Complete guide covering endpoints, frontend integration patterns, configuration, behavior notes, and usage examples

- **Integration**: Registers the AG-UI router in the main FastAPI application and adds `ag-ui-langgraph` dependency

## Notable Implementation Details

- The AG-UI adapter is intentionally thin, delegating event translation to `ag-ui-langgraph` while handling agent registry lookup, auth, and tracing
- Threads are fully shared between protocols—both use the same checkpointer keyed by thread ID
- The `ag-ui-langgraph` package is pinned to pre-1.0 version (`~=0.0.42`) to manage compatibility risk

https://claude.ai/code/session_01GARhFo2wZft9cCfZTqkjhQ