### PR TITLE
Make /history endpoint agent-aware

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -340,17 +340,25 @@ class AgentClient:
             except httpx.HTTPError as e:
                 raise AgentClientError(f"Error: {e}")
 
-    def get_history(self, thread_id: str) -> ChatHistory:
+    def get_history(self, thread_id: str, agent: str | None = None) -> ChatHistory:
         """
         Get chat history.
 
         Args:
             thread_id (str, optional): Thread ID for identifying a conversation
+            agent (str, optional): The agent whose graph should interpret the thread.
+                Threads are shared across agents by thread_id and the server keeps no
+                record of a thread's "owning" agent, so the caller must pass the agent
+                that created the thread — reading it through a different agent's graph
+                returns empty/incomplete history. Defaults to the client's selected
+                agent, falling back to the service default agent.
         """
+        agent = agent or self.agent
         request = ChatHistoryInput(thread_id=thread_id)
+        url = f"{self.base_url}/{agent}/history" if agent else f"{self.base_url}/history"
         try:
             response = httpx.post(
-                f"{self.base_url}/history",
+                url,
                 json=request.model_dump(),
                 headers=self._headers,
                 timeout=self.timeout,

--- a/src/client/client.py
+++ b/src/client/client.py
@@ -347,11 +347,6 @@ class AgentClient:
         Args:
             thread_id (str, optional): Thread ID for identifying a conversation
             agent (str, optional): The agent whose graph should interpret the thread.
-                Threads are shared across agents by thread_id and the server keeps no
-                record of a thread's "owning" agent, so the caller must pass the agent
-                that created the thread — reading it through a different agent's graph
-                returns empty/incomplete history. Defaults to the client's selected
-                agent, falling back to the service default agent.
         """
         agent = agent or self.agent
         request = ChatHistoryInput(thread_id=thread_id)

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -401,13 +401,15 @@ async def feedback(feedback: Feedback) -> FeedbackResponse:
     return FeedbackResponse()
 
 
+@router.post("/{agent_id}/history", operation_id="history_with_agent_id")
 @router.post("/history")
-async def history(input: ChatHistoryInput) -> ChatHistory:
+async def history(input: ChatHistoryInput, agent_id: str = DEFAULT_AGENT) -> ChatHistory:
     """
-    Get chat history.
+    Get chat history for a thread and agent.
+
+    If agent_id is not provided, the default agent will be used.
     """
-    # TODO: Hard-coding DEFAULT_AGENT here is wonky
-    agent: AgentGraph = get_agent(DEFAULT_AGENT)
+    agent: AgentGraph = get_agent(agent_id)
     try:
         state_snapshot = await agent.aget_state(
             config=RunnableConfig(configurable={"thread_id": input.thread_id})

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -276,14 +276,21 @@ def test_get_history(agent_client):
         ]
     }
 
-    # Mock successful response
+    # Mock successful response - defaults to the client's selected agent
     mock_response = Response(200, json=HISTORY, request=Request("POST", "http://test/history"))
-    with patch("httpx.post", return_value=mock_response):
+    with patch("httpx.post", return_value=mock_response) as mock_post:
         history = agent_client.get_history(THREAD_ID)
         assert isinstance(history, ChatHistory)
         assert len(history.messages) == 2
         assert history.messages[0].type == "human"
         assert history.messages[1].type == "ai"
+        # The client's selected agent is used to scope the history request
+        assert mock_post.call_args.args[0] == "http://test/test-agent/history"
+
+    # An explicit agent overrides the client's selected agent
+    with patch("httpx.post", return_value=mock_response) as mock_post:
+        agent_client.get_history(THREAD_ID, agent="chatbot")
+        assert mock_post.call_args.args[0] == "http://test/chatbot/history"
 
     # Test error response
     error_response = Response(

--- a/tests/service/test_service.py
+++ b/tests/service/test_service.py
@@ -212,6 +212,62 @@ def test_history(test_client, mock_agent) -> None:
     assert output.messages[1].content == ANSWER
 
 
+def test_history_custom_agent(test_client) -> None:
+    """Test that /{agent_id}/history reads the thread through the requested agent's graph."""
+    CUSTOM_AGENT = "custom_agent"
+    QUESTION = "What is the weather in Tokyo?"
+    ANSWER = "The weather in Tokyo is 70 degrees."
+
+    custom_snapshot = StateSnapshot(
+        values={"messages": [HumanMessage(content=QUESTION), AIMessage(content=ANSWER)]},
+        next=(),
+        config={},
+        metadata=None,
+        created_at=None,
+        parent_config=None,
+        tasks=(),
+        interrupts=(),
+    )
+    # The default agent's graph doesn't know about this thread, so it returns no messages.
+    default_snapshot = StateSnapshot(
+        values={"messages": []},
+        next=(),
+        config={},
+        metadata=None,
+        created_at=None,
+        parent_config=None,
+        tasks=(),
+        interrupts=(),
+    )
+
+    custom_mock = AsyncMock()
+    custom_mock.aget_state.return_value = custom_snapshot
+    default_mock = AsyncMock()
+    default_mock.aget_state.return_value = default_snapshot
+
+    def agent_lookup(agent_id):
+        if agent_id == CUSTOM_AGENT:
+            return custom_mock
+        return default_mock
+
+    with patch("service.service.get_agent", side_effect=agent_lookup):
+        response = test_client.post(
+            f"/{CUSTOM_AGENT}/history",
+            json={"thread_id": "7bcc7cc1-99d7-4b1d-bdb5-e6f90ed44de6"},
+        )
+        assert response.status_code == 200
+
+        # The custom agent's graph was used, not the default one.
+        custom_mock.aget_state.assert_awaited_once()
+        default_mock.aget_state.assert_not_awaited()
+
+        output = ChatHistory.model_validate(response.json())
+        assert output.messages[0].type == "human"
+        assert output.messages[0].content == QUESTION
+        assert output.messages[1].type == "ai"
+        assert output.messages[1].content == ANSWER
+
+
 @pytest.mark.asyncio
 async def test_stream(test_client, mock_agent) -> None:
     """Test streaming tokens and messages."""

--- a/tests/smoke/test_persistence.py
+++ b/tests/smoke/test_persistence.py
@@ -20,8 +20,10 @@ def test_checkpointer_persists_history():
     can't tell the backends apart, since any working checkpointer would pass).
     Requires a running service (USE_FAKE_MODEL=true) backed by a live database.
 
-    Uses the default agent (rather than pinning one) because /history always reads
-    state through DEFAULT_AGENT regardless of which agent a thread was invoked with.
+    Uses the default agent for both invoke and get_history. Since /history is
+    agent-aware and AgentClient scopes it to the client's selected agent, the same
+    graph that created the thread also reads it back — which is what makes the
+    round-trip work now that each agent is a distinct graph with its own state.
     """
     client = AgentClient("http://localhost:8080")
 


### PR DESCRIPTION
## Problem

The `/history` endpoint hardcoded `get_agent(DEFAULT_AGENT)` (the old `# TODO: Hard-coding DEFAULT_AGENT here is wonky` comment) and read thread state through that single graph. Each agent is a distinct LangGraph graph with its own state channels, so reading a thread through the wrong graph returns empty/incomplete history — `/history` was broken for any thread created with a non-default agent.

Reproduced with `USE_FAKE_MODEL=true`: invoking a thread via `/chatbot/invoke` then calling `/history` returned **0 messages**, while the same flow on `research-assistant` (the default) returned the expected history.

## Changes

**Service** (`src/service/service.py`)
- Add an agent-scoped `POST /{agent_id}/history` route mirroring `/invoke` and `/stream`, using `get_agent(agent_id)`.
- Keep the bare `POST /history` route defaulting to `DEFAULT_AGENT`, so existing callers are unaffected.

**Client** (`src/client/client.py`)
- `AgentClient.get_history()` gains an optional `agent` parameter, defaulting to the client's selected agent (falling back to the service default when unset), and targets the agent-scoped route.

**Docs/tests**
- `tests/service/test_service.py`: new `test_history_custom_agent` proves `/{agent_id}/history` reads through the requested agent's graph, not the default's; existing bare `/history` test unchanged.
- `tests/client/test_client.py`: `test_get_history` asserts the request is agent-scoped and that an explicit `agent` overrides the client's selection.
- `tests/smoke/test_persistence.py`: refreshed a docstring that claimed `/history` always reads through `DEFAULT_AGENT`.

## Scope

This PR is deliberately limited to the **endpoint + client capability**. The share button fix (Tornado→Starlette) landed separately in #330. The Streamlit resume/URL handling that consumes this (carrying the agent in the URL, using `st.selectbox(bind="query-params")`, and related URL cleanups) is intentionally deferred to a **follow-up PR** to keep this one focused.

## Verification

`ruff format`/`check`, `mypy src/`, and the service/client/app test suites pass. Also verified live against a running service with `USE_FAKE_MODEL=true`: `/chatbot/history` returns the chatbot thread's messages while bare `/history` still defaults to `research-assistant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bU77N3HHeE1cSZNRS8W7J