### PR TITLE
Fix share_chat_dialog to use st.context.url instead of private Stream…

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import urllib.parse
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -181,10 +180,7 @@ async def main() -> None:
 
         @st.dialog("Share/resume chat")
         def share_chat_dialog() -> None:
-            session = st.runtime.get_instance()._session_mgr.list_active_sessions()[0]
-            st_base_url = urllib.parse.urlunparse(
-                [session.client.request.protocol, session.client.request.host, "", "", "", ""]
-            )
+            st_base_url = st.context.url
             # if it's not localhost, switch to https by default
             if not st_base_url.startswith("https") and "localhost" not in st_base_url:
                 st_base_url = st_base_url.replace("http", "https")


### PR DESCRIPTION
Fixes #325

## What was broken?

The original code reaches into `st.runtime.get_instance()._session_mgr` — notice the underscore prefix on `_session_mgr`. In Python, a leading underscore is a convention meaning "this is a private/internal attribute, not part of the public API — don't rely on it." Streamlit's maintainers can rename or restructure `_session_mgr` in any release without warning, since it's not a supported public interface.

A newer Streamlit version appears to have changed or removed that internal structure, so `list_active_sessions()[0]` either throws an error, returns something unexpected, or points to the wrong session entirely — causing the error dialog described in the issue ("This app has encountered an error...").

## What I fixed

Replaced the private API call with `st.context.url` — Streamlit's newer, public, documented API for getting the current request's URL. It's stable across versions, which is the actual fix here, not just different syntax doing the same thing.

Also removed the now-unused `session` variable and the `import urllib.parse` line at the top of the file, since both were only needed by the old implementation and would otherwise be flagged as dead code by the linter.

## Testing

Tested manually since the automated Streamlit UI test can't cover this dialog interaction:
- Started a chat, clicked "Share/resume chat" — no error, a clean URL is generated (`http://localhost:8501?thread_id=...&user_id=...`)
- Opened that URL in a fresh tab — confirmed it correctly resumes the same chat thread

Ran the full test suite (`pytest`) — 1 pre-existing failure, unrelated to this change:
- `test_app_simple_non_streaming` fails locally on my machine (Windows, Python 3.14) with `RuntimeError: Could not determine home directory`
- Confirmed via `git stash` that this same test fails identically on unmodified `main`, so it's a pre-existing local environment issue, not something introduced by this PR