### PR TITLE
Streamlit: resume conversations with the right agent via the URL

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -107,12 +107,8 @@ async def main() -> None:
             thread_id = str(uuid.uuid4())
             messages = []
         else:
-            # Resuming a shared thread: read the agent from the URL so history is
-            # fetched through the graph that created the thread. Threads are shared
-            # across agents by thread_id and the server keeps no record of a thread's
-            # owning agent, so reading through the wrong graph returns empty history.
-            # The agent selectbox is bound to the same "agent" query param and adopts
-            # this value when it renders below.
+            # Read the agent from the URL so history is fetched through the graph that
+            # created the thread.
             resume_agent = st.query_params.get("agent") or agent_client.agent
             try:
                 messages: ChatHistory = agent_client.get_history(
@@ -124,9 +120,7 @@ async def main() -> None:
         st.session_state.messages = messages
         st.session_state.thread_id = thread_id
 
-    # Keep the browser URL shareable/resumable at all times so the address bar can be
-    # copied directly. thread_id is synced here; the agent is synced by the selectbox's
-    # query-params binding and user_id by get_or_create_user_id.
+    # Keep thread_id in the URL so the address bar is directly shareable.
     st.query_params["thread_id"] = st.session_state.thread_id
 
     # Config options
@@ -150,9 +144,7 @@ async def main() -> None:
             model = st.selectbox("LLM to use", options=agent_client.info.models, index=model_idx)
             agent_list = [a.key for a in agent_client.info.agents]
             agent_idx = agent_list.index(agent_client.info.default_agent)
-            # bind="query-params" syncs the selection to the ?agent= URL param (and
-            # initializes from it on load), so a shared/resumed URL selects the right
-            # agent. The param is dropped from the URL when the default is selected.
+            # Sync the selection to the ?agent= URL param (dropped when it's the default).
             agent_client.agent = st.selectbox(
                 "Agent to use",
                 options=agent_list,
@@ -200,11 +192,11 @@ async def main() -> None:
 
         @st.dialog("Share/resume chat")
         def share_chat_dialog() -> None:
-            # st.context.url is the browser URL (scheme/host/port/path) with the query
-            # string stripped, so rebuild the params explicitly. Include the agent so
-            # the thread is resumed through the graph that created it, and the user_id
-            # to maintain user identity.
-            st_base_url = (st.context.url or f"http://{os.getenv('HOST', '0.0.0.0')}").rstrip("/")
+            # st.context.url is the browser URL (with query string stripped). Rebuild
+            # the params, including the agent so the thread resumes through the right graph.
+            if not st.context.url:
+                st.error("Could not determine the app URL to build a shareable link.")
+                return
             query = urllib.parse.urlencode(
                 {
                     "thread_id": st.session_state.thread_id,
@@ -212,7 +204,7 @@ async def main() -> None:
                     USER_ID_COOKIE: user_id,
                 }
             )
-            chat_url = f"{st_base_url}?{query}"
+            chat_url = f"{st.context.url}?{query}"
             st.markdown(f"**Chat URL:**\n```text\n{chat_url}\n```")
             st.info("Copy the above URL to share or revisit this chat")
 

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import urllib.parse
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -106,13 +107,27 @@ async def main() -> None:
             thread_id = str(uuid.uuid4())
             messages = []
         else:
+            # Resuming a shared thread: read the agent from the URL so history is
+            # fetched through the graph that created the thread. Threads are shared
+            # across agents by thread_id and the server keeps no record of a thread's
+            # owning agent, so reading through the wrong graph returns empty history.
+            # The agent selectbox is bound to the same "agent" query param and adopts
+            # this value when it renders below.
+            resume_agent = st.query_params.get("agent") or agent_client.agent
             try:
-                messages: ChatHistory = agent_client.get_history(thread_id=thread_id).messages
+                messages: ChatHistory = agent_client.get_history(
+                    thread_id=thread_id, agent=resume_agent
+                ).messages
             except AgentClientError:
                 st.error("No message history found for this Thread ID.")
                 messages = []
         st.session_state.messages = messages
         st.session_state.thread_id = thread_id
+
+    # Keep the browser URL shareable/resumable at all times so the address bar can be
+    # copied directly. thread_id is synced here; the agent is synced by the selectbox's
+    # query-params binding and user_id by get_or_create_user_id.
+    st.query_params["thread_id"] = st.session_state.thread_id
 
     # Config options
     with st.sidebar:
@@ -135,10 +150,15 @@ async def main() -> None:
             model = st.selectbox("LLM to use", options=agent_client.info.models, index=model_idx)
             agent_list = [a.key for a in agent_client.info.agents]
             agent_idx = agent_list.index(agent_client.info.default_agent)
+            # bind="query-params" syncs the selection to the ?agent= URL param (and
+            # initializes from it on load), so a shared/resumed URL selects the right
+            # agent. The param is dropped from the URL when the default is selected.
             agent_client.agent = st.selectbox(
                 "Agent to use",
                 options=agent_list,
                 index=agent_idx,
+                key="agent",
+                bind="query-params",
             )
             use_streaming = st.toggle("Stream results", value=True)
             # Audio toggle with callback: clears cached audio when toggled off
@@ -180,14 +200,19 @@ async def main() -> None:
 
         @st.dialog("Share/resume chat")
         def share_chat_dialog() -> None:
-            st_base_url = st.context.url
-            # if it's not localhost, switch to https by default
-            if not st_base_url.startswith("https") and "localhost" not in st_base_url:
-                st_base_url = st_base_url.replace("http", "https")
-            # Include both thread_id and user_id in the URL for sharing to maintain user identity
-            chat_url = (
-                f"{st_base_url}?thread_id={st.session_state.thread_id}&{USER_ID_COOKIE}={user_id}"
+            # st.context.url is the browser URL (scheme/host/port/path) with the query
+            # string stripped, so rebuild the params explicitly. Include the agent so
+            # the thread is resumed through the graph that created it, and the user_id
+            # to maintain user identity.
+            st_base_url = (st.context.url or f"http://{os.getenv('HOST', '0.0.0.0')}").rstrip("/")
+            query = urllib.parse.urlencode(
+                {
+                    "thread_id": st.session_state.thread_id,
+                    "agent": agent_client.agent,
+                    USER_ID_COOKIE: user_id,
+                }
             )
+            chat_url = f"{st_base_url}?{query}"
             st.markdown(f"**Chat URL:**\n```text\n{chat_url}\n```")
             st.info("Copy the above URL to share or revisit this chat")
 

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -26,7 +26,6 @@ def mock_agent_client(mock_env):
     ):
         mock_agent_client_instance = mock_agent_client.return_value
         mock_agent_client_instance.info = mock_info
-        # Mirror the real client's default selected agent so history requests and the
-        # agent selectbox have a deterministic value.
+        # Give the mock a deterministic selected agent.
         mock_agent_client_instance.agent = "test-agent"
         yield mock_agent_client_instance

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -26,4 +26,7 @@ def mock_agent_client(mock_env):
     ):
         mock_agent_client_instance = mock_agent_client.return_value
         mock_agent_client_instance.info = mock_info
+        # Mirror the real client's default selected agent so history requests and the
+        # agent selectbox have a deterministic value.
+        mock_agent_client_instance.agent = "test-agent"
         yield mock_agent_client_instance

--- a/tests/app/test_streamlit_app.py
+++ b/tests/app/test_streamlit_app.py
@@ -88,10 +88,32 @@ def test_app_thread_id_history(mock_agent_client):
     at.run()
     print(at)
     assert at.session_state.thread_id == "1234"
-    mock_agent_client.get_history.assert_called_with(thread_id="1234")
+    # No agent in the URL, so history is read through the client's selected agent.
+    mock_agent_client.get_history.assert_called_with(thread_id="1234", agent="test-agent")
     assert at.chat_message[0].avatar == "user"
     assert at.chat_message[0].markdown[0].value == "What is the weather?"
     assert at.chat_message[1].avatar == "assistant"
+    assert at.chat_message[1].markdown[0].value == "The weather is sunny."
+    assert not at.exception
+
+
+def test_app_resume_with_agent_param(mock_agent_client):
+    """An ?agent= URL param scopes the resumed history to that agent's graph."""
+
+    at = AppTest.from_file("../../src/streamlit_app.py")
+    at.query_params["thread_id"] = "1234"
+    at.query_params["agent"] = "chatbot"
+    HISTORY = [
+        ChatMessage(type="human", content="What is the weather?"),
+        ChatMessage(type="ai", content="The weather is sunny."),
+    ]
+    mock_agent_client.get_history.return_value = ChatHistory(messages=HISTORY)
+    at.run()
+    print(at)
+    assert at.session_state.thread_id == "1234"
+    # History is fetched through the agent named in the URL, not the default.
+    mock_agent_client.get_history.assert_called_with(thread_id="1234", agent="chatbot")
+    assert at.chat_message[0].markdown[0].value == "What is the weather?"
     assert at.chat_message[1].markdown[0].value == "The weather is sunny."
     assert not at.exception
 


### PR DESCRIPTION
## Context

Follow-up to #329 (agent-aware `/history`). The endpoint and client can now scope history by agent; this wires the Streamlit app to actually use it. Previously the app read history through whatever agent happened to be selected, so **resuming a shared thread created by a non-default agent returned empty history** — the selectbox reset to the default before the resume fetch ran.

## Changes (`src/streamlit_app.py`)

- **Bind the agent selectbox to the `?agent=` query param** via the new `st.selectbox(..., key="agent", bind="query-params")` (Streamlit ≥1.45, and the repo pins `~=1.58`). Selecting an agent updates the URL; loading a URL with `?agent=` selects that agent. The param is **dropped when the default agent is selected**, keeping the URL clean.
- **On resume**, read the agent from the URL and fetch history through that agent's graph. The selectbox (bound to the same param) adopts the value when it renders.
- **Keep `thread_id` in the URL at all times**, so the address bar is directly copyable/shareable without opening the dialog (agent is synced by the binding, `user_id` was already synced).
- **Share dialog**: rebuild the URL with `urllib.parse.urlencode` and include the agent; drop the now-unnecessary force-`https` heuristic, since `st.context.url` (added in #330) reports the browser's real scheme.

## Tests

- `tests/app/test_streamlit_app.py`: new `test_app_resume_with_agent_param` (a `?agent=` URL scopes the resumed history to that agent); updated `test_app_thread_id_history` for the agent-scoped call.
- `tests/app/conftest.py`: give the mock client a deterministic `agent`.

## Verification

Driven end-to-end in a **headless browser** against a live `USE_FAKE_MODEL=true` service (Streamlit 1.58):

- Selecting `chatbot` → `?agent=chatbot` appears in the URL; switching back to the default **removes** `?agent=`.
- `thread_id` is present in the address bar from first load.
- Opening the copied URL in a fresh context **restores history through the chatbot graph** and shows `chatbot` selected.
- Share dialog produces a complete URL and doesn't crash.
- **No page errors** in any flow — in particular, reading `st.query_params.get("agent")` at the top of the script (before the bound widget renders) works cleanly with no rerun loop.

`ruff format`/`check`, `mypy src/`, and `pytest` (137 passed, 3 skipped) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bU77N3HHeE1cSZNRS8W7J

---
_Generated by [Claude Code](https://claude.ai/code/session_019bU77N3HHeE1cSZNRS8W7J)_