### PR TITLE
Sentinel playbook: in-progress CI rule, workflow filter, redirect wording

### DIFF
--- a/docs/maintenance/Daily_Sentinel.md
+++ b/docs/maintenance/Daily_Sentinel.md
@@ -42,15 +42,19 @@ the biweekly maintenance run's digest (`Weekly_Maintenance_Run.md`).
    issues/PRs (plus items closed within the last 7 days — regression reports
    and abuse sometimes land on freshly-closed threads), new PRs on
    JoshuaC215/agent-service-toolkit.
-2. **CI on main:** the most recent run of the test workflow on `main` — is it
-   failing?
+2. **CI on main:** the most recent `test.yml` run on `main` — is it failing?
+   Filter to that workflow (several fire per push, and unfiltered run listings
+   overflow). If the latest run is still in progress, judge from the last
+   *completed* run; if the in-progress run started more than ~15 minutes ago,
+   wait for it rather than skating past the ambiguity.
 3. **Live app:** the egress proxy doesn't support WebSockets, so the browser
    round-trip (`scripts/smoke_live_app.py`) can't run here — it covers
    localhost in the weekly dependency ladder instead. Probe the front-end
    shell: `curl -sL --max-time 30 -c /tmp/st.jar -b /tmp/st.jar
-   https://agent-service-toolkit.streamlit.app/` → expect a final 200 with app
-   HTML (Streamlit Cloud 303s anonymous visitors via `share.streamlit.io`).
-   A wake-up/error page or non-200 is a real signal. One retry; route
+   https://agent-service-toolkit.streamlit.app/` → expect a final 200 with
+   Streamlit shell HTML (a redirect hop via `share.streamlit.io` may or may
+   not appear — the chain varies). A wake-up/error page or non-200 is a real
+   signal. One retry; route
    connection-layer failures (reset/timeout/CONNECT 403) through the proxy
    diagnosis (`/root/.ccr/README.md`) first — those are rule 5, not "app
    down."
@@ -82,9 +86,9 @@ End the session with a short alert message:
 
 - What happened, with links.
 - Why it clears the bar (one line).
-- The suggested next step, and what the sentinel already verified (e.g. "smoke
-  test failed twice, service /health also unreachable — looks like the Azure
-  backend, not Streamlit").
+- The suggested next step, and what the sentinel already verified (e.g. "shell
+  probe returned 5xx twice after retry and proxy checks — looks like Streamlit
+  Cloud or the app container, not repo code").
 
 Diagnose as far as read-only access allows, but do not fix, revert, or reply on
 GitHub — the maintainer decides the response, possibly by continuing this very

--- a/docs/maintenance/Weekly_Maintenance_Run.md
+++ b/docs/maintenance/Weekly_Maintenance_Run.md
@@ -148,8 +148,8 @@ The egress proxy doesn't support WebSockets, so the browser round-trip
 (`scripts/smoke_live_app.py`) can't run against the deployed app from a routine
 session — it runs against **localhost** in Phase F's dependency ladder instead.
 Probe the front-end shell: `curl -sL -c /tmp/st.jar -b /tmp/st.jar
-https://agent-service-toolkit.streamlit.app/` → expect a final 200 with app
-HTML after the `share.streamlit.io` redirect; a wake-up or error page is a
+https://agent-service-toolkit.streamlit.app/` → expect a final 200 with
+Streamlit shell HTML (redirect chain may vary); a wake-up or error page is a
 finding (the visit also keeps the app awake). Report in the digest's Health
 section; route connection-layer failures through the proxy diagnosis
 (`/root/.ccr/README.md`) before calling it an outage.


### PR DESCRIPTION
Amendments from reviewing the second manual sentinel run:

- CI check: filter to `test.yml` (unfiltered run listings overflow); if the latest run is in progress, judge from the last completed run, and wait if it started >15 min ago instead of skating past it.
- Live-app probe: expect a 200 with Streamlit shell HTML, redirect chain may vary (this run got a direct 200 with no `share.streamlit.io` hop).
- Fixed the stale alert example that still referenced probing the backend `/health` (removed in #334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RmY3vXPHHcDf3Vu7CUxH3

---
_Generated by [Claude Code](https://claude.ai/code/session_013RmY3vXPHHcDf3Vu7CUxH3)_