### PR TITLE
Model refresh: add GPT-5.6, Claude Sonnet 5, Gemini 3.5 Flash; drop retired models

### DIFF
--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -106,6 +106,11 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
             openai_api_key=settings.DEEPSEEK_API_KEY,
         )
     if model_name in AnthropicModelName:
+        if model_name == AnthropicModelName.SONNET_5:
+            # Claude Sonnet 5 rejects non-default sampling parameters (temperature,
+            # top_p, top_k) with a 400 error -- adaptive thinking is on by default
+            # instead. See https://docs.anthropic.com/en/docs/about-claude/models
+            return ChatAnthropic(model=api_model_name, streaming=True)
         return ChatAnthropic(model=api_model_name, temperature=0.5, streaming=True)
     if model_name in GoogleModelName:
         return ChatGoogleGenerativeAI(model=api_model_name, temperature=0.5, streaming=True)

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -183,7 +183,7 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(OpenAICompatibleName))
                 case Provider.DEEPSEEK:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = DeepseekModelName.DEEPSEEK_CHAT
+                        self.DEFAULT_MODEL = DeepseekModelName.DEEPSEEK_V4_FLASH
                     self.AVAILABLE_MODELS.update(set(DeepseekModelName))
                 case Provider.ANTHROPIC:
                     if self.DEFAULT_MODEL is None:
@@ -191,11 +191,11 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(AnthropicModelName))
                 case Provider.GOOGLE:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = GoogleModelName.GEMINI_20_FLASH
+                        self.DEFAULT_MODEL = GoogleModelName.GEMINI_35_FLASH
                     self.AVAILABLE_MODELS.update(set(GoogleModelName))
                 case Provider.VERTEXAI:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = VertexAIModelName.GEMINI_20_FLASH
+                        self.DEFAULT_MODEL = VertexAIModelName.GEMINI_35_FLASH
                     self.AVAILABLE_MODELS.update(set(VertexAIModelName))
                 case Provider.GROQ:
                     if self.DEFAULT_MODEL is None:
@@ -211,7 +211,7 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(OllamaModelName))
                 case Provider.OPENROUTER:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = OpenRouterModelName.GEMINI_25_FLASH
+                        self.DEFAULT_MODEL = OpenRouterModelName.GEMINI_35_FLASH
                     self.AVAILABLE_MODELS.update(set(OpenRouterModelName))
                 case Provider.FAKE:
                     if self.DEFAULT_MODEL is None:

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -22,6 +22,9 @@ class OpenAIModelName(StrEnum):
     GPT_5_NANO = "gpt-5-nano"
     GPT_5_MINI = "gpt-5-mini"
     GPT_5_1 = "gpt-5.1"
+    GPT_56_LUNA = "gpt-5.6-luna"
+    GPT_56_TERRA = "gpt-5.6-terra"
+    GPT_56_SOL = "gpt-5.6-sol"
 
 
 class AzureOpenAIModelName(StrEnum):
@@ -34,7 +37,7 @@ class AzureOpenAIModelName(StrEnum):
 class DeepseekModelName(StrEnum):
     """https://api-docs.deepseek.com/quick_start/pricing"""
 
-    DEEPSEEK_CHAT = "deepseek-chat"
+    DEEPSEEK_V4_FLASH = "deepseek-v4-flash"
 
 
 class AnthropicModelName(StrEnum):
@@ -42,36 +45,35 @@ class AnthropicModelName(StrEnum):
 
     HAIKU_45 = "claude-haiku-4-5"
     SONNET_45 = "claude-sonnet-4-5"
+    SONNET_5 = "claude-sonnet-5"
 
 
 class GoogleModelName(StrEnum):
     """https://ai.google.dev/gemini-api/docs/models/gemini"""
 
-    GEMINI_15_PRO = "gemini-1.5-pro"
-    GEMINI_20_FLASH = "gemini-2.0-flash"
-    GEMINI_20_FLASH_LITE = "gemini-2.0-flash-lite"
-    GEMINI_25_FLASH = "gemini-2.5-flash"
     GEMINI_25_PRO = "gemini-2.5-pro"
+    GEMINI_31_FLASH_LITE = "gemini-3.1-flash-lite"
+    GEMINI_35_FLASH = "gemini-3.5-flash"
     GEMINI_30_PRO = "gemini-3-pro-preview"
 
 
 class VertexAIModelName(StrEnum):
     """https://cloud.google.com/vertex-ai/generative-ai/docs/models"""
 
-    GEMINI_15_PRO = "gemini-1.5-pro"
-    GEMINI_20_FLASH = "gemini-2.0-flash"
-    GEMINI_20_FLASH_LITE = "models/gemini-2.0-flash-lite"
-    GEMINI_25_FLASH = "models/gemini-2.5-flash"
     GEMINI_25_PRO = "gemini-2.5-pro"
+    GEMINI_31_FLASH_LITE = "models/gemini-3.1-flash-lite"
+    GEMINI_35_FLASH = "models/gemini-3.5-flash"
     GEMINI_30_PRO = "gemini-3-pro-preview"
 
 
 class GroqModelName(StrEnum):
     """https://console.groq.com/docs/models"""
 
-    LLAMA_31_8B = "llama-3.1-8b"
-    LLAMA_33_70B = "llama-3.3-70b"
+    LLAMA_31_8B = "llama-3.1-8b-instant"
+    LLAMA_33_70B = "llama-3.3-70b-versatile"
 
+    GPT_OSS_20B = "openai/gpt-oss-20b"
+    GPT_OSS_120B = "openai/gpt-oss-120b"
     GPT_OSS_SAFEGUARD_20B = "openai/gpt-oss-safeguard-20b"
 
 
@@ -91,7 +93,7 @@ class OllamaModelName(StrEnum):
 class OpenRouterModelName(StrEnum):
     """https://openrouter.ai/models"""
 
-    GEMINI_25_FLASH = "google/gemini-2.5-flash"
+    GEMINI_35_FLASH = "google/gemini-3.5-flash"
 
 
 class OpenAICompatibleName(StrEnum):

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -35,11 +35,21 @@ def test_get_model_anthropic():
         assert model.streaming is True
 
 
+def test_get_model_anthropic_sonnet_5_omits_temperature():
+    # Claude Sonnet 5 rejects non-default sampling parameters with a 400 error,
+    # so get_model must not pass temperature for this model.
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"}):
+        model = get_model(AnthropicModelName.SONNET_5)
+        assert isinstance(model, ChatAnthropic)
+        assert model.model == "claude-sonnet-5"
+        assert model.streaming is True
+
+
 def test_get_model_groq():
     with patch.dict(os.environ, {"GROQ_API_KEY": "test_key"}):
         model = get_model(GroqModelName.LLAMA_31_8B)
         assert isinstance(model, ChatGroq)
-        assert model.model_name == "llama-3.1-8b"
+        assert model.model_name == "llama-3.1-8b-instant"
         assert model.temperature == 0.5
 
 
@@ -49,6 +59,15 @@ def test_get_model_groq_guard():
         assert isinstance(model, ChatGroq)
         assert model.model_name == "openai/gpt-oss-safeguard-20b"
         assert model.temperature < 0.01
+
+
+def test_get_model_groq_gpt_oss():
+    with patch.dict(os.environ, {"GROQ_API_KEY": "test_key"}):
+        model = get_model(GroqModelName.GPT_OSS_120B)
+        assert isinstance(model, ChatGroq)
+        assert model.model_name == "openai/gpt-oss-120b"
+        # Only the safeguard variant gets the temperature=0.0 override.
+        assert model.temperature == 0.5
 
 
 def test_get_model_ollama():

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -62,7 +62,7 @@ def test_settings_with_vertexai_credentials_file():
     with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "test_key"}, clear=True):
         settings = Settings(_env_file=None)
         assert settings.GOOGLE_APPLICATION_CREDENTIALS == SecretStr("test_key")
-        assert settings.DEFAULT_MODEL == VertexAIModelName.GEMINI_20_FLASH
+        assert settings.DEFAULT_MODEL == VertexAIModelName.GEMINI_35_FLASH
         assert settings.AVAILABLE_MODELS == set(VertexAIModelName)
 
 


### PR DESCRIPTION
## Summary

Scheduled biweekly model-catalog audit (`docs/maintenance/Weekly_Maintenance_Run.md`, Phase E / model-refresh skill). Compared `src/schema/models.py` against each provider's current docs, then live-verified every changed model with `scripts/check_live_models.py` against real API keys (OpenAI, Anthropic, Google, Groq).

### Added
- **OpenAI**: `gpt-5.6-luna` / `gpt-5.6-terra` / `gpt-5.6-sol` — OpenAI's new three-tier GPT-5.6 family, GA July 9, 2026. ([OpenAI: GPT-5.6](https://openai.com/index/gpt-5-6/)) Existing `gpt-5-nano`/`gpt-5-mini`/`gpt-5.1` are **not** deprecated for API use (only retired from the ChatGPT UI), so they're kept rather than swapped out.
- **Anthropic**: `claude-sonnet-5` — GA. ([Claude docs: Models overview](https://docs.anthropic.com/en/docs/about-claude/models#model-names)) `claude-sonnet-4-5` and `claude-haiku-4-5` remain active per Anthropic's docs, unchanged.
- **Google / Vertex AI**: `gemini-3.5-flash` and `gemini-3.1-flash-lite` — both GA. ([Gemini API: Models](https://ai.google.dev/gemini-api/docs/models/gemini))
- **Groq**: `openai/gpt-oss-20b` and `openai/gpt-oss-120b` — Groq's vendor-recommended replacements ahead of Llama 3.1-8b/3.3-70b's announced Aug 16, 2026 sunset. ([Groq: Model Deprecations](https://console.groq.com/docs/deprecations))
- **DeepSeek**: `deepseek-v4-flash` (replaces `deepseek-chat`).
- **OpenRouter**: `google/gemini-3.5-flash` (replaces `google/gemini-2.5-flash`).

### Removed
- **Google / Vertex AI**: `gemini-1.5-pro` (fully retired — live calls now 404), `gemini-2.0-flash` and `gemini-2.0-flash-lite` (provider shutdown date 2026-06-01, already passed), and `gemini-2.5-flash` (a live call today returned `"This model models/gemini-2.5-flash is no longer available to new users"`). `gemini-2.5-pro` and `gemini-3-pro-preview` are untouched.
- **DeepSeek**: `deepseek-chat` — DeepSeek's docs say it will be deprecated 2026-07-24 and already transparently aliases to `deepseek-v4-flash`.
- **OpenRouter**: `google/gemini-2.5-flash` — mirrors the direct Google API removal above.

### Fixed
- **Groq**: `llama-3.1-8b` → `llama-3.1-8b-instant`, `llama-3.3-70b` → `llama-3.3-70b-versatile`. The old bare names live-404 against the Groq API today ("model does not exist"); this looks like a pre-existing bug in the catalog, not a recent provider change. Confirmed working with the corrected suffixes.
- **`src/core/llm.py`**: `get_model()` now omits the `temperature` kwarg specifically for `claude-sonnet-5` — Anthropic's docs say Sonnet 5 rejects any non-default sampling parameter (temperature/top_p/top_k) with a 400 (adaptive thinking is on by default instead), and a live call confirmed the 400 before this fix.

### DEFAULT_MODEL changes
- Google, Vertex AI, and OpenRouter `DEFAULT_MODEL` repointed at `gemini-3.5-flash` (their prior default, `gemini-2.0-flash`/`gemini-2.5-flash`, was removed above). DeepSeek's default moves to `deepseek-v4-flash` for the same reason. OpenAI/Anthropic/Groq defaults are unchanged (their previous default models are still live).

### Breaking-change note
The Groq `llama-3.1-8b`/`llama-3.3-70b` value rename is a breaking change for any deployment pinning those exact strings via `DEFAULT_MODEL`/`AVAILABLE_MODELS` env config — though since the old values already 404 live, this should only fix broken configs rather than break working ones.

### Not changed
- **AWS Bedrock, Azure OpenAI, Vertex AI-via-service-account, OpenRouter, DeepSeek**: no credentials were available in this environment to live-verify, so their catalog entries were updated from docs research only (Bedrock/Azure not touched at all — see below).
- **AWS Bedrock** (`bedrock-3.5-haiku` / `bedrock-3.5-sonnet`): these values don't look like real Bedrock model IDs (real IDs look like `anthropic.claude-haiku-4-5-20251001-v1:0`, sometimes with a `us.`/`global.` inference-profile prefix). This looks like a pre-existing issue unrelated to model freshness. Left untouched since there's no way to verify the correct ID format without AWS credentials — flagging for a follow-up with someone who has Bedrock access.
- **Azure OpenAI**: still on `gpt-4o`/`gpt-4o-mini`. Azure is deployment-based and lags OpenAI's own catalog; updating it would also mean changing the hardcoded `required_models` validation in `settings.py` and several tests. Left out of this pass given no Azure credentials to verify against.
- Anthropic's separate Opus (`claude-opus-4-8`) and Fable (`claude-fable-5`) tiers were deliberately **not** added — this catalog has never carried an Opus-class model (cost-conscious scope), so adding a new tier felt like a product decision beyond a routine freshness refresh. Flagging as an option for the maintainer to consider separately.

## Live verification (`scripts/check_live_models.py`)

| Provider | Status | Notes |
|---|---|---|
| OpenAI | Ran | All 6 models PASS on repeat run; `gpt-5.6-sol` intermittently returned a 401 "insufficient permissions" on 2 of 3 runs (passed once) — looks like an access-tier/org-verification gate on the newest flagship, not a wrong model ID. |
| Anthropic | Ran (`--anthropic-api-key-env LIVE_TEST_CLAUDE_KEY`) | All 3 models PASS, including `claude-sonnet-5` after the temperature fix. |
| Google | Ran | `gemini-3.5-flash` and `gemini-3.1-flash-lite` PASS. `gemini-2.5-pro` and `gemini-3-pro-preview` (untouched by this PR) hit 429 quota-exceeded on the test key — inconclusive, not evidence of deprecation. |
| Groq | Ran | All 5 models PASS after the `-instant`/`-versatile` suffix fix. |
| DeepSeek, OpenRouter, AWS Bedrock, Azure OpenAI, Vertex AI (service account) | Skipped | No credentials configured in this environment. |

## Test plan
- [x] `PYTHONPATH=src uv run pytest tests/` — 139 passed, 3 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] `PYTHONPATH=src uv run python scripts/check_live_models.py --anthropic-api-key-env LIVE_TEST_CLAUDE_KEY` (see table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9cmjmYpYtKSpuECRjybeQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01J9cmjmYpYtKSpuECRjybeQ)_