### PR TITLE
Upgrade Azure and AWS Bedrock models to latest generations

### DIFF
--- a/.claude/skills/model-refresh/SKILL.md
+++ b/.claude/skills/model-refresh/SKILL.md
@@ -46,6 +46,12 @@ per-provider `DEFAULT_MODEL` fallbacks point at a model that still exists.
      vs `gemini-2.5-flash`) — check both columns. Ollama takes a user-supplied
      model name at runtime, so there's nothing to add there; just confirm the
      generic pass-through in `llm.py` still works.
+   - **`docs.aws.amazon.com` returns HTTP 403 to `WebFetch`** (it blocks the
+     fetcher's user agent — this is not an egress-policy denial). Use `WebSearch`
+     for Bedrock model IDs instead; it reads the same doc pages server-side and
+     surfaces the model-card and inference-profile-support pages. The per-model
+     card pages (`.../model-card-anthropic-claude-<model>.html`) list the exact
+     `modelId` and profile IDs.
 2. **Classify each gap:**
    - *New model, generally available* → add it.
    - *New model, preview/experimental* → use judgment; this repo has taken preview
@@ -89,6 +95,47 @@ per-provider `DEFAULT_MODEL` fallbacks point at a model that still exists.
    for existing deployments pinning the old enum value in `DEFAULT_MODEL`/
    `AVAILABLE_MODELS` env config, not something to swap silently. Commit and push
    per the repo's normal git workflow; open a PR only if asked.
+
+## Providers you can't live-verify (Bedrock, Azure, Vertex service-account, DeepSeek, OpenRouter)
+
+Not having a key for a provider is **not** a reason to skip it — a stale or
+broken catalog entry is worse than a doc-sourced one. Update these from docs
+just like the rest, and in the PR mark them explicitly as **doc-only /
+unverified**, citing the provider page and calling out any caveat below so the
+next person with a key knows exactly what to spot-check. Only leave a provider
+untouched when the docs themselves are ambiguous *and* the change would be a
+product decision (e.g. adding a whole new pricing tier), not a freshness update.
+
+- **AWS Bedrock** — the enum *value* is passed straight to `ChatBedrock(model_id=...)`,
+  so it must be a real Bedrock ID, not a friendly label. Two gotchas:
+  1. The latest Claude models are **not invocable on-demand by their base model
+     ID** — a bare `anthropic.claude-...` call 400s with "on-demand throughput
+     isn't supported." They must go through a cross-region **inference profile**:
+     the base ID prefixed with a geo (`us.`/`eu.`/`apac.`) or `global.`. Prefer
+     `global.` (routes dynamically, region-agnostic — the best fit for a catalog
+     value with no region context) and note in the PR that single-region
+     deployments not enrolled in Global CRIS should swap the prefix for their geo.
+  2. Bedrock inherits the same **sampling-parameter restrictions** as the direct
+     Anthropic API — e.g. a Sonnet-5-class model rejects `temperature`. If you
+     point a Bedrock entry at such a model, mirror the no-`temperature` branch
+     that already exists for it in `llm.py`'s Anthropic and Bedrock dispatch.
+  If AWS credentials happen to be present, `boto3.client("bedrock").list_foundation_models()`
+  is the fastest way to confirm real IDs — but note that Bedrock access is a
+  separate enablement from plain AWS creds, so this can fail with an auth error
+  even when other AWS calls would work.
+- **Azure OpenAI** is the one genuinely heavier lift, because it's deployment-based
+  and the catalog is coupled in more places than the enum:
+  - `settings.py` `model_post_init` hardcodes a `required_models` set (currently
+    `{"gpt-4o", "gpt-4o-mini"}`) that it validates the `AZURE_OPENAI_DEPLOYMENT_MAP`
+    against — bumping the enum means bumping that set and the `.env.example`
+    deployment-map sample and the ~7 Azure cases in `tests/core/test_settings.py`.
+  - `llm.py` hardcodes `temperature=0.5` for the Azure path, but Azure's GPT-5-era
+    **reasoning** variants reject `temperature` (400). If you move Azure onto one,
+    add a no-`temperature` branch like the Anthropic/Bedrock Sonnet-5 handling.
+  - Changing an Azure enum value is a **breaking change** to every user's
+    deployment map (they name deployments after these keys). Treat an Azure
+    generation bump as its own reviewed change, and flag the deployment-map break
+    loudly — don't fold it silently into a routine refresh.
 
 ## Live testing
 

--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,7 @@ OPENWEATHERMAP_API_KEY=
 # Add for running Azure OpenAI
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 # AZURE_OPENAI_API_VERSION=2024-10-21
-# AZURE_OPENAI_DEPLOYMENT_MAP={"gpt-4o": "gpt-4o-deployment", "gpt-4o-mini": "gpt-4o-mini-deployment"}
+# AZURE_OPENAI_DEPLOYMENT_MAP={"gpt-5": "gpt-5-deployment", "gpt-5-mini": "gpt-5-mini-deployment"}
 
 # Agent URL: used in Streamlit app - if not set, defaults to http://{HOST}:{PORT}
 # AGENT_URL=http://localhost:8080

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -88,9 +88,7 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
         if not settings.AZURE_OPENAI_API_KEY or not settings.AZURE_OPENAI_ENDPOINT:
             raise ValueError("Azure OpenAI API key and endpoint must be configured")
 
-        # Azure's GPT-5 generation is reasoning-based and rejects non-default
-        # sampling parameters (temperature, top_p, ...) with a 400, so don't set
-        # temperature here -- mirrors the OpenAI direct path above.
+        # GPT-5 generation is reasoning-based and rejects temperature (400); omit it.
         return AzureChatOpenAI(
             azure_endpoint=settings.AZURE_OPENAI_ENDPOINT,
             deployment_name=api_model_name,
@@ -124,9 +122,7 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
         return ChatGroq(model=api_model_name, temperature=0.5)  # type: ignore[call-arg]
     if model_name in AWSModelName:
         if model_name == AWSModelName.BEDROCK_SONNET:
-            # Claude Sonnet 5 rejects non-default sampling parameters (temperature,
-            # top_p, top_k) with a 400 -- adaptive thinking is on by default. This
-            # holds on Bedrock too, same as the direct Anthropic API above.
+            # Sonnet 5 rejects non-default sampling params (400); omit temperature.
             return ChatBedrock(model_id=api_model_name)
         return ChatBedrock(model_id=api_model_name, temperature=0.5)
     if model_name in OllamaModelName:

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -88,11 +88,13 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
         if not settings.AZURE_OPENAI_API_KEY or not settings.AZURE_OPENAI_ENDPOINT:
             raise ValueError("Azure OpenAI API key and endpoint must be configured")
 
+        # Azure's GPT-5 generation is reasoning-based and rejects non-default
+        # sampling parameters (temperature, top_p, ...) with a 400, so don't set
+        # temperature here -- mirrors the OpenAI direct path above.
         return AzureChatOpenAI(
             azure_endpoint=settings.AZURE_OPENAI_ENDPOINT,
             deployment_name=api_model_name,
             api_version=settings.AZURE_OPENAI_API_VERSION,
-            temperature=0.5,
             streaming=True,
             timeout=60,
             max_retries=3,

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -121,6 +121,11 @@ def get_model(model_name: AllModelEnum, /) -> ModelT:
             return ChatGroq(model=api_model_name, temperature=0.0)  # type: ignore[call-arg]
         return ChatGroq(model=api_model_name, temperature=0.5)  # type: ignore[call-arg]
     if model_name in AWSModelName:
+        if model_name == AWSModelName.BEDROCK_SONNET:
+            # Claude Sonnet 5 rejects non-default sampling parameters (temperature,
+            # top_p, top_k) with a 400 -- adaptive thinking is on by default. This
+            # holds on Bedrock too, same as the direct Anthropic API above.
+            return ChatBedrock(model_id=api_model_name)
         return ChatBedrock(model_id=api_model_name, temperature=0.5)
     if model_name in OllamaModelName:
         if settings.OLLAMA_BASE_URL:

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -219,7 +219,7 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(FakeModelName))
                 case Provider.AZURE_OPENAI:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = AzureOpenAIModelName.AZURE_GPT_4O_MINI
+                        self.DEFAULT_MODEL = AzureOpenAIModelName.AZURE_GPT_5_MINI
                     self.AVAILABLE_MODELS.update(set(AzureOpenAIModelName))
                     # Validate Azure OpenAI settings if Azure provider is available
                     if not self.AZURE_OPENAI_API_KEY:
@@ -239,7 +239,7 @@ class Settings(BaseSettings):
                             raise ValueError(f"Invalid AZURE_OPENAI_DEPLOYMENT_MAP JSON: {e}")
 
                     # Validate required deployments exist
-                    required_models = {"gpt-4o", "gpt-4o-mini"}
+                    required_models = {"gpt-5", "gpt-5-mini"}
                     missing_models = required_models - set(self.AZURE_OPENAI_DEPLOYMENT_MAP.keys())
                     if missing_models:
                         raise ValueError(f"Missing required Azure deployments: {missing_models}")

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -28,10 +28,17 @@ class OpenAIModelName(StrEnum):
 
 
 class AzureOpenAIModelName(StrEnum):
-    """Azure OpenAI model names"""
+    """https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
 
-    AZURE_GPT_4O = "azure-gpt-4o"
-    AZURE_GPT_4O_MINI = "azure-gpt-4o-mini"
+    Azure is deployment-based: these values are used as Azure deployment names and
+    are cross-checked against AZURE_OPENAI_DEPLOYMENT_MAP / the required_models set
+    in settings.py. Renaming a value is a breaking change for existing deployment
+    maps. The GPT-5 generation is reasoning-based and rejects sampling parameters
+    like temperature (see llm.py).
+    """
+
+    AZURE_GPT_5 = "azure-gpt-5"
+    AZURE_GPT_5_MINI = "azure-gpt-5-mini"
 
 
 class DeepseekModelName(StrEnum):

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -78,10 +78,19 @@ class GroqModelName(StrEnum):
 
 
 class AWSModelName(StrEnum):
-    """https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html"""
+    """https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
 
-    BEDROCK_HAIKU = "bedrock-3.5-haiku"
-    BEDROCK_SONNET = "bedrock-3.5-sonnet"
+    Values are Bedrock cross-region inference profile IDs, not bare foundation
+    model IDs. The latest Claude models on Bedrock reject on-demand invocation of
+    the base model ID ("on-demand throughput isn't supported") and must be called
+    through an inference profile prefixed with a geo (``us.``/``eu.``/``apac.``)
+    or ``global.``. ``global.`` routes dynamically and is the most portable
+    default; single-region deployments not enrolled in Global cross-Region
+    inference should swap it for their geo prefix (e.g. ``us.``).
+    """
+
+    BEDROCK_HAIKU = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+    BEDROCK_SONNET = "global.anthropic.claude-sonnet-5"
 
 
 class OllamaModelName(StrEnum):

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -28,15 +28,9 @@ class OpenAIModelName(StrEnum):
 
 
 class AzureOpenAIModelName(StrEnum):
-    """https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
+    """https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure"""
 
-    Azure is deployment-based: these values are used as Azure deployment names and
-    are cross-checked against AZURE_OPENAI_DEPLOYMENT_MAP / the required_models set
-    in settings.py. Renaming a value is a breaking change for existing deployment
-    maps. The GPT-5 generation is reasoning-based and rejects sampling parameters
-    like temperature (see llm.py).
-    """
-
+    # Values double as Azure deployment names / required_models keys; renaming breaks existing deployment maps.
     AZURE_GPT_5 = "azure-gpt-5"
     AZURE_GPT_5_MINI = "azure-gpt-5-mini"
 
@@ -85,17 +79,9 @@ class GroqModelName(StrEnum):
 
 
 class AWSModelName(StrEnum):
-    """https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+    """https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html"""
 
-    Values are Bedrock cross-region inference profile IDs, not bare foundation
-    model IDs. The latest Claude models on Bedrock reject on-demand invocation of
-    the base model ID ("on-demand throughput isn't supported") and must be called
-    through an inference profile prefixed with a geo (``us.``/``eu.``/``apac.``)
-    or ``global.``. ``global.`` routes dynamically and is the most portable
-    default; single-region deployments not enrolled in Global cross-Region
-    inference should swap it for their geo prefix (e.g. ``us.``).
-    """
-
+    # Values are global cross-region inference profile IDs; latest Claude on Bedrock rejects bare on-demand model IDs. Single-region deployments may need a us./eu. prefix instead.
     BEDROCK_HAIKU = "global.anthropic.claude-haiku-4-5-20251001-v1:0"
     BEDROCK_SONNET = "global.anthropic.claude-sonnet-5"
 

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -105,13 +105,13 @@ def test_settings_with_azure_openai_key():
         {
             "AZURE_OPENAI_API_KEY": "test_key",
             "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
-            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-4o": "deployment-1", "gpt-4o-mini": "deployment-2"}',
+            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-5": "deployment-1", "gpt-5-mini": "deployment-2"}',
         },
         clear=True,
     ):
         settings = Settings(_env_file=None)
         assert settings.AZURE_OPENAI_API_KEY.get_secret_value() == "test_key"
-        assert settings.DEFAULT_MODEL == AzureOpenAIModelName.AZURE_GPT_4O_MINI
+        assert settings.DEFAULT_MODEL == AzureOpenAIModelName.AZURE_GPT_5_MINI
         assert settings.AVAILABLE_MODELS == set(AzureOpenAIModelName)
 
 
@@ -122,7 +122,7 @@ def test_settings_with_both_openai_and_azure():
             "OPENAI_API_KEY": "test_openai_key",
             "AZURE_OPENAI_API_KEY": "test_azure_key",
             "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
-            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-4o": "deployment-1", "gpt-4o-mini": "deployment-2"}',
+            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-5": "deployment-1", "gpt-5-mini": "deployment-2"}',
         },
         clear=True,
     ):
@@ -161,14 +161,14 @@ def test_settings_azure_deployment_map():
         {
             "AZURE_OPENAI_API_KEY": "test_key",
             "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
-            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-4o": "deploy1", "gpt-4o-mini": "deploy2"}',
+            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-5": "deploy1", "gpt-5-mini": "deploy2"}',
         },
         clear=True,
     ):
         settings = Settings(_env_file=None)
         assert settings.AZURE_OPENAI_DEPLOYMENT_MAP == {
-            "gpt-4o": "deploy1",
-            "gpt-4o-mini": "deploy2",
+            "gpt-5": "deploy1",
+            "gpt-5-mini": "deploy2",
         }
 
 
@@ -178,7 +178,7 @@ def test_settings_azure_invalid_deployment_map():
         {
             "AZURE_OPENAI_API_KEY": "test_key",
             "AZURE_OPENAI_ENDPOINT": "https://test.openai.azure.com",
-            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-4o": "deploy1"}',  # Missing required model
+            "AZURE_OPENAI_DEPLOYMENT_MAP": '{"gpt-5": "deploy1"}',  # Missing required model
         },
         clear=True,
     ):
@@ -188,7 +188,7 @@ def test_settings_azure_invalid_deployment_map():
 
 def test_settings_azure_openai():
     """Test Azure OpenAI settings."""
-    deployment_map = {"gpt-4o": "deployment1", "gpt-4o-mini": "deployment2"}
+    deployment_map = {"gpt-5": "deployment1", "gpt-5-mini": "deployment2"}
     with patch.dict(
         os.environ,
         {


### PR DESCRIPTION
## Summary
Updates model catalogs and configurations for Azure OpenAI and AWS Bedrock to support the latest model generations, with corresponding adjustments to sampling parameters and deployment mappings.

## Key Changes

**Azure OpenAI: GPT-4o → GPT-5 migration**
- Updated `AzureOpenAIModelName` enum from `AZURE_GPT_4O` / `AZURE_GPT_4O_MINI` to `AZURE_GPT_5` / `AZURE_GPT_5_MINI`
- Removed hardcoded `temperature=0.5` from Azure path in `llm.py` — GPT-5 reasoning models reject non-default sampling parameters with 400 errors
- Updated required deployment map keys in `settings.py` from `gpt-4o`/`gpt-4o-mini` to `gpt-5`/`gpt-5-mini`
- Updated `.env.example` and all test fixtures to reflect new deployment names
- Added documentation noting this is a **breaking change** for existing deployment maps

**AWS Bedrock: Inference profile IDs and Sonnet-5 handling**
- Changed `BEDROCK_HAIKU` from `bedrock-3.5-haiku` to `global.anthropic.claude-haiku-4-5-20251001-v1:0` (inference profile format)
- Changed `BEDROCK_SONNET` from `bedrock-3.5-sonnet` to `global.anthropic.claude-sonnet-5` (inference profile format)
- Added special handling in `llm.py` for `BEDROCK_SONNET` to omit `temperature` parameter (Sonnet-5 rejects sampling parameters, same as direct Anthropic API)
- Updated docstring to explain that values must be cross-region inference profile IDs (not bare foundation model IDs), with guidance on geo prefixes for single-region deployments

**Documentation improvements**
- Expanded `.claude/skills/model-refresh/SKILL.md` with new section on providers without live-verification keys (Bedrock, Azure, Vertex, DeepSeek, OpenRouter)
- Added detailed Bedrock gotchas: inference profile requirement, sampling parameter restrictions, and `boto3` verification method
- Added Azure-specific guidance on deployment-map coupling, required_models validation, and breaking-change implications
- Added note about `docs.aws.amazon.com` blocking WebFetch (use WebSearch instead)

## Notable Implementation Details

- The `global.` prefix for Bedrock inference profiles provides dynamic region routing and is recommended as the portable default; users with single-region deployments should swap it for their geo prefix (e.g., `us.`)
- Both Azure GPT-5 and Bedrock Sonnet-5 follow the same no-temperature pattern already established for Anthropic direct API calls
- Azure deployment-map changes require users to update their `AZURE_OPENAI_DEPLOYMENT_MAP` environment variable — this is flagged as a breaking change in documentation

https://claude.ai/code/session_01RyegMUEdXbZhw9HtvXVqB1