### PR TITLE
Add scheduled live smoke-test workflow and wire result into weekly check-in

### DIFF
--- a/.github/workflows/live-smoke-test.yml
+++ b/.github/workflows/live-smoke-test.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   smoke:
+    # Only run against the maintainer's deployed app, not in template clones/forks
+    if: github.repository == 'JoshuaC215/agent-service-toolkit'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/live-smoke-test.yml
+++ b/.github/workflows/live-smoke-test.yml
@@ -1,0 +1,55 @@
+name: Live smoke test
+
+# Weekly browser round-trip against the deployed Streamlit demo: loads the app,
+# sends one chat message, and verifies an assistant response streams back
+# (browser -> Streamlit websocket -> agent service -> LLM -> back). Runs an hour
+# before the Sunday maintenance run so that run has a fresh result to report.
+on:
+  schedule:
+    - cron: "0 9 * * 0"
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Target app URL to smoke test (leave blank to use the script default)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-smoke-test
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          version: "0.11.28"
+      - name: Install Playwright Chromium
+        run: uv run --with playwright playwright install --with-deps chromium
+      - name: Run live smoke test
+        env:
+          LIVE_APP_URL: ${{ github.event.inputs.url }}
+        run: |
+          # On scheduled runs there is no dispatch input, so LIVE_APP_URL is the
+          # empty string; unset it so the script falls back to its default URL.
+          [ -z "${LIVE_APP_URL}" ] && unset LIVE_APP_URL
+          uv run --with playwright python scripts/smoke_live_app.py
+      - name: Upload failure screenshot
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-live-app-failure
+          path: smoke_live_app_failure.png
+          if-no-files-found: warn

--- a/docs/maintenance/Weekly_Maintenance_Run.md
+++ b/docs/maintenance/Weekly_Maintenance_Run.md
@@ -207,6 +207,33 @@ finding (the visit also keeps the app awake). Report in the digest's Health
 section; route connection-layer failures through the proxy diagnosis
 (`/root/.ccr/README.md`) before calling it an outage.
 
+**Full browser round-trip — read the `live-smoke-test.yml` workflow result.**
+The curl probe above only proves the SPA shell loads; the actual chat round-trip
+(browser → Streamlit websocket → agent service → LLM → back) is exercised by the
+scheduled **Live smoke test** workflow (`.github/workflows/live-smoke-test.yml`),
+which runs `scripts/smoke_live_app.py` on a GitHub-hosted runner every Sunday at
+09:00 UTC — an hour before this run — because that runner has no WebSocket-egress
+restriction. This session is a **consumer** of that result: do **not** try to run
+Playwright or open a WebSocket here.
+
+- Look up the workflow's latest **completed** run by its file id, not by scanning
+  all runs: `mcp__github__actions_list` for workflow `live-smoke-test.yml`
+  (`status: completed`, newest first), or `gh run list --workflow live-smoke-test.yml`
+  if the check-in uses `gh`. Read the top run's `conclusion`, `html_url`, and
+  `created_at`.
+- **Staleness / false-green guard:** the workflow fires weekly, so a healthy
+  signal is a completed run **< 8 days old**. If the latest completed run is
+  older than that, the schedule didn't fire — report "**no fresh signal** (last
+  live smoke run was <date>, older than the weekly cadence)" and do **not** pass
+  off the stale `conclusion` as current. Optionally kick a fresh run with
+  `mcp__github__actions_run_trigger` (`workflow_dispatch` on `live-smoke-test.yml`)
+  and read that instead — only if a bounded wait fits this run's 90-minute
+  deadline; otherwise just flag the staleness.
+- Report inline in the digest's Health section alongside the curl probe: pass/fail,
+  the run's `html_url`, and when it ran. On **failure**, point at the run's
+  uploaded `smoke-live-app-failure` artifact (the `smoke_live_app_failure.png`
+  screenshot) so the screenshot is one click away without re-running anything.
+
 ## Phase D — Infra smoke tests (every run)
 
 Run the full suite every run: `./scripts/smoke_test.sh all` (Postgres, MongoDB,


### PR DESCRIPTION
## Summary

Adds a recurring end-to-end signal that the deployed demo path is alive: browser → Streamlit (WebSocket) → agent service → LLM → response back. The `scripts/smoke_live_app.py` browser round-trip can't run from the maintenance check-in's environment (outbound WebSocket is blocked there), but GitHub-hosted runners have no such restriction — so this runs the existing script there and makes the weekly check-in a *consumer* of the result.

## Changes

**New workflow — `.github/workflows/live-smoke-test.yml`**
- **Triggers:** `schedule` weekly (`0 9 * * 0`, Sunday 09:00 UTC — one hour before the Sunday maintenance run so it has a fresh result to read) plus `workflow_dispatch` with an optional `url` input.
- **Steps:** checkout → setup-python (from `pyproject.toml`) → install uv → `uv run --with playwright playwright install --with-deps chromium` → `uv run --with playwright python scripts/smoke_live_app.py`. The script imports only Playwright + stdlib, so no project deps are synced.
- The `url` input maps to the script's `LIVE_APP_URL`; a shell guard unsets the empty env var on scheduled runs so the script falls back to its built-in `DEFAULT_URL` (`os.environ.get` would otherwise treat `""` as an override).
- **No secrets** — hits the public deployed app; the LLM call happens server-side.
- `if: failure()` uploads `smoke_live_app_failure.png` as an artifact; the script's non-zero exit fails the job so it's visible in the Actions tab. Adds `timeout-minutes: 10` and a `concurrency` group to avoid overlap.
- Action pins and uv/Python setup mirror `test.yml` (`checkout@v7`, `setup-python@v6`, `setup-uv@v8.3.2` with uv `0.11.28`).

**Weekly check-in — Phase C of `docs/maintenance/Weekly_Maintenance_Run.md`**
- Adds a step to read the latest *completed* run of `live-smoke-test.yml` by its file id (via `mcp__github__actions_list` / `gh`), reporting `conclusion`, `html_url`, and `created_at` inline in the digest's Health section alongside the existing curl shell probe.
- On failure, points at the run's uploaded `smoke-live-app-failure` artifact (the screenshot) so it's one click away.
- Staleness guard: a healthy signal is a completed run < 8 days old; if the latest is older the schedule didn't fire, so it reports "no fresh signal" rather than passing off a stale conclusion as current. Optionally kicks a fresh `workflow_dispatch` if that fits the run's deadline.
- The check-in stays a consumer — it does not drive Playwright or a WebSocket itself.

## Verification

- Workflow YAML parses; `pymarkdown` passes on the edited doc. `actionlint` couldn't run (its download is blocked by this environment's egress).
- Running the script locally reached `page.goto` then hit `ERR_CONNECTION_RESET` — the exact WebSocket/egress restriction that motivates running it on Actions. Chromium launched fine, confirming the script mechanics; a real green requires an Actions run (via `workflow_dispatch` once merged).

## Note for reviewers

The task brief said this repo pins Actions to commit SHAs; it actually pins to version tags (`test.yml`, `deploy.yml`), so this workflow follows the real convention — version tags. `actions/upload-artifact@v4` is the one action not already used elsewhere in the repo (v4 is the current major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRMmf32kj6J1RXCQ8RcHcq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRMmf32kj6J1RXCQ8RcHcq)_