### PR TITLE
Add one-shot template-cleanup workflow for downstream clones

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -1,0 +1,60 @@
+name: Template cleanup
+
+# One-shot cleanup that runs the first time this template is instantiated into a
+# downstream repo. It strips maintainer-only scaffolding, commits the result, then
+# deletes itself so it never runs again. The owner-guard below makes it a no-op in
+# the source repo.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    # Only ever run in downstream template copies, never in the source repo.
+    if: github.repository != 'JoshuaC215/agent-service-toolkit'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Remove maintainer scaffolding
+        run: |
+          set -euo pipefail
+
+          # Whole-directory buckets: maintainer automation and maintenance docs.
+          rm -rf .claude docs/maintenance
+
+          # Owner-guarded workflows self-identify via the maintainer owner-guard, so
+          # new guarded workflows are covered without editing this list. Skip the
+          # generic CI (test.yml, which has no guard) and this file (deleted last).
+          guard="github.repository == 'JoshuaC215/agent-service-toolkit'"
+          for wf in .github/workflows/*.yml; do
+            [ "$wf" = ".github/workflows/template-cleanup.yml" ] && continue
+            if grep -qF "$guard" "$wf"; then
+              rm -f "$wf"
+            fi
+          done
+
+          # Explicit list: maintainer-only files in shared dirs that cannot carry the
+          # owner-guard marker. Keep in sync with the CLAUDE.md convention.
+          # (none currently)
+
+          # Delete self last so this workflow never runs again.
+          rm -f .github/workflows/template-cleanup.yml
+
+      - name: Commit cleanup
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "Nothing to clean up."
+            exit 0
+          fi
+          git add -A
+          git commit -m "Remove maintainer scaffolding from template instance"
+          git push origin HEAD:${{ github.ref_name }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,20 @@
 - Never write multi-paragraph comment blocks or over-explain inline. Match the terseness of the surrounding code.
 - Exception: brand-new files may start with a short, genuinely useful module/file-level docstring. This does not license verbose inline comments throughout the rest of the file.
 - When editing an existing file, match its existing comment density and style rather than introducing a heavier style than what's already there.
+
+## Maintainer scaffolding vs. template content
+
+This repo is a GitHub template. `.github/workflows/template-cleanup.yml` strips
+maintainer-only scaffolding from downstream clones on first instantiation, driven by
+conventions rather than a hardcoded list. Put new scaffolding where the cleanup already
+covers it:
+
+- Maintainer automation (skills, hooks, scheduled runs) goes in `.claude/` or
+  `docs/maintenance/` — whole-directory buckets, removed entirely, auto-covered.
+- A maintainer-only *workflow* must carry the owner-guard
+  `if: github.repository == 'JoshuaC215/agent-service-toolkit'` line; the cleanup
+  removes any guarded workflow, so this is auto-covered too.
+- ONLY when a maintainer-only file must live in a shared dir (`scripts/`, etc.) and
+  can't carry the guard marker do you add it to the explicit list in
+  `template-cleanup.yml`. Adding such a file without updating the cleanup is the one
+  case that leaks scaffolding into clones.


### PR DESCRIPTION
## What & why

Turns this repo into a clean GitHub template. When someone instantiates the template into their own repo, they don't want the maintainer-only scaffolding (automation skills, scheduled live smoke test, Azure deploy pipeline, maintenance docs). This adds a one-shot workflow that removes that scaffolding automatically on first push, then self-deletes.

## Changes

### `.github/workflows/template-cleanup.yml` (new)

- Triggers on `push` to `main` (fires on template instantiation).
- Guarded with `if: github.repository != 'JoshuaC215/agent-service-toolkit'` — the inverse of the existing maintainer owner-guard — so it's a **no-op in the source repo**.
- Convention-driven removal, so it rarely needs editing:
  - **Whole-directory buckets**, removed entirely: `.claude/` and `docs/maintenance/`.
  - **Owner-guarded workflows**: removes any `.github/workflows/*.yml` whose body contains the maintainer owner-guard `if: github.repository == 'JoshuaC215/agent-service-toolkit'`. This is self-identifying, so `deploy.yml` and `live-smoke-test.yml` are caught today and any future guarded workflow is auto-covered. Generic CI (`test.yml`, no guard) is kept.
- Commits the result and pushes, then deletes itself last so it never runs again. Pins actions to version tags (`checkout@v7`) like the other workflows.

Dry-run against the current workflows confirms: `deploy.yml` → remove, `live-smoke-test.yml` → remove, `test.yml` → keep, `template-cleanup.yml` → skip/self-delete.

### `CLAUDE.md`

Adds a short "Maintainer scaffolding vs. template content" section documenting the convention: new maintainer automation belongs in `.claude/` or `docs/maintenance/` (whole-dir, auto-covered), or if it must be a workflow it carries the owner-guard `if:` line (auto-covered). Only a maintainer-only file forced into a shared dir (`scripts/`, etc.) that can't carry the guard needs an explicit entry in the cleanup — and that's the one case that would otherwise leak scaffolding into clones.

## Verification

- YAML parses (`yaml.safe_load`).
- Removal logic dry-run matches the intended keep/remove set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016p3CxQ4oEGQHAhbgtqZwB9)_