### PR TITLE
Handle Streamlit Community Cloud iframe in live smoke test

### DIFF
--- a/.github/workflows/live-smoke-test.yml
+++ b/.github/workflows/live-smoke-test.yml
@@ -46,11 +46,31 @@ jobs:
         run: |
           # On scheduled runs there is no dispatch input, so LIVE_APP_URL is the
           # empty string; unset it so the script falls back to its default URL.
-          [ -z "${LIVE_APP_URL}" ] && unset LIVE_APP_URL
-          uv run --with playwright python scripts/smoke_live_app.py
+          # Use an explicit if (not `&& unset`) so a set URL doesn't trip `bash -e`.
+          if [ -z "${LIVE_APP_URL}" ]; then unset LIVE_APP_URL; fi
+          set -o pipefail
+          uv run --with playwright python scripts/smoke_live_app.py 2>&1 | tee smoke_run.log
+      - name: Failure summary
+        if: failure()
+        run: |
+          {
+            echo "## ❌ Live smoke test failed"
+            echo ""
+            echo "Target: \`${LIVE_APP_URL:-script default}\`"
+            echo ""
+            echo "Diagnostics (page title, iframe count, data-testid inventory, visible text):"
+            echo '```'
+            diag=$(grep '\[smoke_live_app\]' smoke_run.log 2>/dev/null | tail -n 40)
+            echo "${diag:-(no diagnostic lines captured)}"
+            echo '```'
+            echo ""
+            echo "📸 Full-page screenshot: download the **smoke-live-app-failure** artifact below."
+          } >> "$GITHUB_STEP_SUMMARY"
+        env:
+          LIVE_APP_URL: ${{ github.event.inputs.url }}
       - name: Upload failure screenshot
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-live-app-failure
           path: smoke_live_app_failure.png

--- a/scripts/smoke_live_app.py
+++ b/scripts/smoke_live_app.py
@@ -33,6 +33,7 @@ DEFAULT_URL = "https://agent-service-toolkit.streamlit.app/"
 # used as a fallback when the installed playwright's own browser build is absent.
 CLOUD_CHROMIUM = "/opt/pw-browsers/chromium"
 TEST_MESSAGE = "Reply with the single word: pong"
+CHAT_INPUT_SELECTOR = '[data-testid="stChatInput"] textarea'
 WAKE_TIMEOUT_S = 180
 RESPONSE_TIMEOUT_S = 120
 STREAM_SETTLE_S = 4
@@ -42,8 +43,40 @@ def log(msg: str) -> None:
     print(f"[smoke_live_app] {msg}", flush=True)
 
 
+def _dump_testids(ctx, label: str) -> None:
+    try:
+        ids = ctx.locator("[data-testid]").evaluate_all(
+            "els => Array.from(new Set(els.map(e => e.getAttribute('data-testid')))).slice(0, 40)"
+        )
+        log(f"data-testids in {label} ({len(ids)}): {ids}")
+    except Exception as e:
+        log(f"data-testids in {label} unavailable: {e}")
+
+
+def dump_diagnostics(page) -> None:
+    """Text diagnostics for a failed run, readable straight from the CI logs."""
+    try:
+        log(f"page title: {page.title()!r}  url: {page.url}")
+    except Exception:
+        pass
+    n_iframes = page.locator("iframe").count()
+    log(f"iframes present: {n_iframes}")
+    _dump_testids(page, "top frame")
+    for i in range(n_iframes):
+        _dump_testids(page.frame_locator("iframe").nth(i), f"iframe[{i}]")
+    try:
+        body = (page.locator("body").inner_text(timeout=2_000) or "").strip()
+        log(f"top-frame visible text ({len(body)} chars): {body[:600]!r}")
+    except Exception:
+        pass
+
+
 def fail(page, reason: str) -> None:
     log(f"FAIL: {reason}")
+    try:
+        dump_diagnostics(page)
+    except Exception as e:
+        log(f"diagnostics unavailable: {e}")
     try:
         page.screenshot(path="smoke_live_app_failure.png", full_page=True)
         log("screenshot saved to smoke_live_app_failure.png")
@@ -61,6 +94,24 @@ def wake_if_sleeping(page) -> None:
         return  # not sleeping
     log("app is asleep - clicking wake-up button")
     wake_button.first.click()
+
+
+def find_app_root(page, timeout_s: int):
+    """Return the page or iframe context that holds the app's chat input.
+
+    Local runs render the app at the top level; Streamlit Community Cloud wraps it
+    in an iframe that page.locator() can't see into, so probe iframes as well.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if page.locator(CHAT_INPUT_SELECTOR).count():
+            return page
+        for i in range(page.locator("iframe").count()):
+            frame = page.frame_locator("iframe").nth(i)
+            if frame.locator(CHAT_INPUT_SELECTOR).count():
+                return frame
+        time.sleep(1)
+    return None
 
 
 def main() -> None:
@@ -82,15 +133,16 @@ def main() -> None:
         wake_if_sleeping(page)
 
         # The chat input appearing means Streamlit booted, the websocket is up,
-        # and the app script ran (it renders after agent/model init).
-        chat_input = page.locator('[data-testid="stChatInput"] textarea')
-        try:
-            chat_input.wait_for(state="visible", timeout=WAKE_TIMEOUT_S * 1_000)
-        except PlaywrightTimeoutError:
+        # and the app script ran (it renders after agent/model init). Resolve
+        # whether it lives at the top level (local) or inside the Community Cloud
+        # iframe, and run every app interaction against that context.
+        root = find_app_root(page, WAKE_TIMEOUT_S)
+        if root is None:
             fail(page, f"chat input never appeared within {WAKE_TIMEOUT_S}s")
-        log("app loaded, chat input visible")
+        log(f"app loaded, chat input visible ({'top-level' if root is page else 'iframe'})")
 
-        messages = page.locator('[data-testid="stChatMessage"]')
+        chat_input = root.locator(CHAT_INPUT_SELECTOR)
+        messages = root.locator('[data-testid="stChatMessage"]')
         # The welcome message only renders on an empty thread and disappears on
         # the rerun after sending, so detection is text-based, not count-based.
         pre_send_last = (messages.last.inner_text() or "").strip() if messages.count() else ""


### PR DESCRIPTION
## Summary

The scheduled live smoke test (added in #346) failed against the deployed app with `chat input never appeared within 180s` — but the app was actually **up and healthy** (screenshot showed the welcome message and chat input rendered). Root cause: **Streamlit Community Cloud runs the app inside an iframe**, and Playwright's `page.locator()` does not descend into iframes, so the chat-input selector never matched. The test was authored against the **local** app, which renders at the top level, so it passed locally and only failed against the deployment.

## Changes

**`scripts/smoke_live_app.py`**
- `find_app_root()` resolves a single `root` context — the top page locally, the app iframe on Community Cloud — by probing for the chat input, and every app interaction runs against `root`. Auto-detected (no flag), so local and deployed both work, with no per-test `if/else`.
- `dump_diagnostics()` on failure logs page title/url, **iframe count**, the `data-testid` inventory of the top frame **and each iframe**, and a visible-text snippet — all readable straight from the CI logs, so the next DOM drift is diagnosable without opening the screenshot.

**`.github/workflows/live-smoke-test.yml`**
- On failure, writes those diagnostics into a **job step summary** (`$GITHUB_STEP_SUMMARY`) so the result is visible on the run page without downloading the artifact.
- Bumps `actions/upload-artifact` `v4 → v7` (off the deprecated Node 20 runtime).
- Switches the `LIVE_APP_URL` guard from `[ -z … ] && unset` to an explicit `if` — the old form would trip `bash -e` and abort the step whenever a `workflow_dispatch` override URL *was* provided.

## Verification

Stood up the service + Streamlit app locally with the fake model:
- ✅ Smoke test passes; now logs `app loaded, chat input visible (top-level)`.
- ✅ `find_app_root` correctly resolves top-level locally (`iframes present: 0`).
- ✅ `dump_diagnostics` runs without error and produces the full testid inventory (`stChatInput`, `stChatInputTextArea`, `stChatMessage`, …).
- ✅ `ruff` clean; workflow YAML parses; both `LIVE_APP_URL` branches and the summary's grep-fallback verified under `bash -e`.

I can't reach the deployed DOM from the dev sandbox (WebSocket egress is blocked), so the iframe path is verified by construction plus the local regression, not against Community Cloud directly. The probe descends one iframe level; if the deployment nests the app deeper, the next run would still fail — but now with diagnostics showing exactly that. Recommend confirming with a `workflow_dispatch` run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRMmf32kj6J1RXCQ8RcHcq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRMmf32kj6J1RXCQ8RcHcq)_