### PR TITLE
Refresh LLM model catalog: Gemini 3.6/3.5-lite additions, drop retired 3-pro-preview

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -195,11 +195,11 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(AnthropicModelName))
                 case Provider.GOOGLE:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = GoogleModelName.GEMINI_35_FLASH
+                        self.DEFAULT_MODEL = GoogleModelName.GEMINI_36_FLASH
                     self.AVAILABLE_MODELS.update(set(GoogleModelName))
                 case Provider.VERTEXAI:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = VertexAIModelName.GEMINI_35_FLASH
+                        self.DEFAULT_MODEL = VertexAIModelName.GEMINI_36_FLASH
                     self.AVAILABLE_MODELS.update(set(VertexAIModelName))
                 case Provider.GROQ:
                     if self.DEFAULT_MODEL is None:
@@ -215,7 +215,7 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(OllamaModelName))
                 case Provider.OPENROUTER:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = OpenRouterModelName.GEMINI_35_FLASH
+                        self.DEFAULT_MODEL = OpenRouterModelName.GEMINI_36_FLASH
                     self.AVAILABLE_MODELS.update(set(OpenRouterModelName))
                 case Provider.FAKE:
                     if self.DEFAULT_MODEL is None:

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -17,7 +17,7 @@ class Provider(StrEnum):
 
 
 class OpenAIModelName(StrEnum):
-    """https://platform.openai.com/docs/models/gpt-4o"""
+    """https://platform.openai.com/docs/models"""
 
     GPT_5_NANO = "gpt-5-nano"
     GPT_5_MINI = "gpt-5-mini"
@@ -39,10 +39,11 @@ class DeepseekModelName(StrEnum):
     """https://api-docs.deepseek.com/quick_start/pricing"""
 
     DEEPSEEK_V4_FLASH = "deepseek-v4-flash"
+    DEEPSEEK_V4_PRO = "deepseek-v4-pro"
 
 
 class AnthropicModelName(StrEnum):
-    """https://docs.anthropic.com/en/docs/about-claude/models#model-names"""
+    """https://platform.claude.com/docs/en/docs/about-claude/models"""
 
     HAIKU_45 = "claude-haiku-4-5"
     SONNET_45 = "claude-sonnet-4-5"
@@ -55,7 +56,10 @@ class GoogleModelName(StrEnum):
     GEMINI_25_PRO = "gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "gemini-3.5-flash"
-    GEMINI_30_PRO = "gemini-3-pro-preview"
+    GEMINI_35_FLASH_LITE = "gemini-3.5-flash-lite"
+    GEMINI_36_FLASH = "gemini-3.6-flash"
+    # gemini-3-pro-preview was shut down 2026-03-09; 3.1 is the current preview-tier pro model.
+    GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
 
 
 class VertexAIModelName(StrEnum):
@@ -64,7 +68,10 @@ class VertexAIModelName(StrEnum):
     GEMINI_25_PRO = "gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "models/gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "models/gemini-3.5-flash"
-    GEMINI_30_PRO = "gemini-3-pro-preview"
+    GEMINI_35_FLASH_LITE = "models/gemini-3.5-flash-lite"
+    GEMINI_36_FLASH = "models/gemini-3.6-flash"
+    # gemini-3-pro-preview was shut down 2026-03-09; 3.1 is the current preview-tier pro model.
+    GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
 
 
 class GroqModelName(StrEnum):
@@ -96,6 +103,7 @@ class OpenRouterModelName(StrEnum):
     """https://openrouter.ai/models"""
 
     GEMINI_35_FLASH = "google/gemini-3.5-flash"
+    GEMINI_36_FLASH = "google/gemini-3.6-flash"
 
 
 class OpenAICompatibleName(StrEnum):

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -63,7 +63,7 @@ def test_settings_with_vertexai_credentials_file():
     with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "test_key"}, clear=True):
         settings = Settings(_env_file=None)
         assert settings.GOOGLE_APPLICATION_CREDENTIALS == SecretStr("test_key")
-        assert settings.DEFAULT_MODEL == VertexAIModelName.GEMINI_35_FLASH
+        assert settings.DEFAULT_MODEL == VertexAIModelName.GEMINI_36_FLASH
         assert settings.AVAILABLE_MODELS == set(VertexAIModelName)
 
 


### PR DESCRIPTION
Periodic (first-of-month) model-catalog refresh per `.claude/skills/model-refresh/SKILL.md`: audited `src/schema/models.py` against each provider's current docs, plus a live smoke test (`scripts/check_live_models.py`) against OpenAI, Anthropic, Google, and Groq.

## Changes

**Google / VertexAI / OpenRouter**
- `gemini-3-pro-preview` was shut down 2026-03-09 ([Gemini deprecations](https://ai.google.dev/gemini-api/docs/deprecations)) — replaced with `gemini-3.1-pro-preview`, the current preview-tier pro model (no GA pro-tier alternative exists yet, consistent with this repo's past practice of taking a preview model when there's no GA option).
- Added `gemini-3.6-flash` and `gemini-3.5-flash-lite` — new GA releases as of 2026-07-21 ([Gemini API models](https://ai.google.dev/gemini-api/docs/models/gemini), [Google blog announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/)). Repointed `DEFAULT_MODEL` at `gemini-3.6-flash` for Google/VertexAI/OpenRouter.
- Left `gemini-2.5-pro`, `gemini-3.1-flash-lite`, and `gemini-3.5-flash` untouched — still served, not flagged for migration.
- Deliberately **skipped** `gemini-3.5-flash-cyber`: a limited-access security-specialist variant gated to Google's CodeMender pilot (governments/trusted enterprise partners only), not a general-purpose GA chat model.

**DeepSeek**
- Added `deepseek-v4-pro` (GA) alongside the existing `deepseek-v4-flash` default ([DeepSeek pricing docs](https://api-docs.deepseek.com/quick_start/pricing)).

**Anthropic / OpenAI / Groq / Azure / AWS — no catalog changes**
- Anthropic: `claude-haiku-4-5`, `claude-sonnet-4-5`, and `claude-sonnet-5` are all still active per the [Claude models overview](https://platform.claude.com/docs/en/docs/about-claude/models). Claude Fable 5 / Opus 4.8 / Mythos 5 remain intentionally out of scope, matching this catalog's existing Haiku/Sonnet-only convention (see #337).
- OpenAI: GPT-5.6 (luna/terra/sol) and gpt-5/5.1-tier models are all still current per [OpenAI's models page](https://platform.openai.com/docs/models).
- Groq: `llama-3.1-8b-instant` / `llama-3.3-70b-versatile` are still production models today, but Groq has announced their retirement for **2026-08-16** in favor of `openai/gpt-oss-20b`/`120b` (already in the catalog per [Groq's deprecations page](https://console.groq.com/docs/deprecations)). Flagging this for next month's refresh rather than swapping the still-served default early.
- Azure OpenAI / AWS Bedrock: left as-is, doc-only/unverified this pass (no credentials to live-verify) — no evidence of a required change on either front this cycle.

**Docstring URL fixes** (old links now 301-redirect):
- OpenAI: `platform.openai.com/docs/models/gpt-4o` → `platform.openai.com/docs/models`
- Anthropic: `docs.anthropic.com/en/docs/about-claude/models` → `platform.claude.com/docs/en/docs/about-claude/models`

## Live verification (`scripts/check_live_models.py`)

| Provider | Result |
|---|---|
| OpenAI | PASS 6/6 (gpt-5-nano, gpt-5-mini, gpt-5.1, gpt-5.6-luna/terra/sol) |
| Anthropic | PASS 3/3 (via `--anthropic-api-key-env LIVE_TEST_CLAUDE_KEY` remap) |
| Groq | PASS 5/5 |
| Google | PASS 4/6 — `gemini-3.1-flash-lite`, `gemini-3.5-flash`, `gemini-3.5-flash-lite`, `gemini-3.6-flash` all PASS. `gemini-2.5-pro` and `gemini-3.1-pro-preview` both returned HTTP 429 `"limit: 0"` for the free-tier Pro-model quota on this key — not a 404/not-found, so the model names are confirmed valid; the pre-existing `gemini-2.5-pro` entry hits the identical quota wall, so this isn't a regression from this PR. |
| Azure OpenAI / AWS Bedrock | Skipped — no credentials in this environment; doc-only per the model-refresh skill. |

Full test suite (`pytest tests/`) passes: 142 passed, 3 skipped. `ruff check` clean on all touched files.

---

🤖 Generated by the Phase E maintenance run (model-refresh).

Claude-Session: https://claude.ai/code/session_01UF2jBfwsxs8owJnH3bnKfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UF2jBfwsxs8owJnH3bnKfD)_