### PR TITLE
Gitignore ephemeral Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ package-lock.json
 
 # Live-app smoke test failure screenshot (scripts/smoke_live_app.py)
 smoke_live_app_failure.png
+
+# Claude Code agent worktrees (ephemeral, per-agent git checkouts)
+.claude/worktrees/


### PR DESCRIPTION
.claude/worktrees/ holds per-agent git checkouts created by background subagents (e.g. the Phase E/F maintenance runs); they shouldn't be tracked.


Claude-Session: https://claude.ai/code/session_01UF2jBfwsxs8owJnH3bnKfD