### PR TITLE
fix: extend model allowlist to AG-UI; revert #305's thread-ownership check

### DIFF
--- a/docs/AGUI.md
+++ b/docs/AGUI.md
@@ -69,7 +69,9 @@ THREAD_ID=my-thread node client.mjs "And another one" chatbot
 - **Per-request configuration** goes in `forwardedProps.configurable` — the AG-UI equivalent of
   the vanilla API's `model` / `user_id` / `agent_config` fields, e.g.
   `{"forwardedProps": {"configurable": {"model": "gpt-5.2"}}}`. Keys managed by the protocol
-  (`thread_id`, `checkpoint_id`, `checkpoint_ns`) are rejected.
+  (`thread_id`, `checkpoint_id`, `checkpoint_ns`) are rejected. `model` is checked against
+  `AVAILABLE_MODELS` (400 if not allowed) and `user_id` is checked against the thread's stored
+  owner (403 on mismatch), same as the vanilla API.
 - **Interrupts** (human-in-the-loop) surface as a `CUSTOM` event named `on_interrupt`. Resume by
   running the same thread again with `{"forwardedProps": {"command": {"resume": <answer>}}}`.
 - **Graph state is client-visible.** AG-UI's shared-state feature sends `STATE_SNAPSHOT` events

--- a/docs/AGUI.md
+++ b/docs/AGUI.md
@@ -70,8 +70,7 @@ THREAD_ID=my-thread node client.mjs "And another one" chatbot
   the vanilla API's `model` / `user_id` / `agent_config` fields, e.g.
   `{"forwardedProps": {"configurable": {"model": "gpt-5.2"}}}`. Keys managed by the protocol
   (`thread_id`, `checkpoint_id`, `checkpoint_ns`) are rejected. `model` is checked against
-  `AVAILABLE_MODELS` (400 if not allowed) and `user_id` is checked against the thread's stored
-  owner (403 on mismatch), same as the vanilla API.
+  `AVAILABLE_MODELS` (400 if not allowed), same as the vanilla API.
 - **Interrupts** (human-in-the-loop) surface as a `CUSTOM` event named `on_interrupt`. Resume by
   running the same thread again with `{"forwardedProps": {"command": {"resume": <answer>}}}`.
 - **Graph state is client-visible.** AG-UI's shared-state feature sends `STATE_SNAPSHOT` events

--- a/src/schema/schema.py
+++ b/src/schema/schema.py
@@ -169,11 +169,6 @@ class ChatHistoryInput(BaseModel):
         description="Thread ID to persist and continue a multi-turn conversation.",
         examples=["847c6285-8fc9-4560-a83f-4e6285809254"],
     )
-    user_id: str | None = Field(
-        description="User ID used to validate thread ownership. Must match the user_id that created the thread.",
-        default=None,
-        examples=["847c6285-8fc9-4560-a83f-4e6285809254"],
-    )
 
 
 class ChatHistory(BaseModel):

--- a/src/service/agui.py
+++ b/src/service/agui.py
@@ -12,6 +12,7 @@ See docs/AGUI.md for usage, including how to connect a client.
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
+from uuid import uuid4
 
 from ag_ui.core import EventType, RunAgentInput
 from ag_ui.encoder import EventEncoder
@@ -23,6 +24,7 @@ from langfuse.langchain import CallbackHandler  # type: ignore[import-untyped]
 
 from agents import DEFAULT_AGENT, AgentGraph, get_agent
 from core import settings
+from service.utils import ensure_model_available, ensure_thread_ownership
 
 logger = logging.getLogger(__name__)
 
@@ -33,13 +35,17 @@ router = APIRouter(prefix="/agui")
 RESERVED_CONFIGURABLE_KEYS = {"thread_id", "checkpoint_id", "checkpoint_ns"}
 
 
-def _base_config(input_data: RunAgentInput) -> RunnableConfig:
+async def _base_config(input_data: RunAgentInput, graph: AgentGraph) -> RunnableConfig:
     """Build the base RunnableConfig for an AG-UI run.
 
     Clients can pass configurable values (e.g. `model`, `user_id`, or custom agent
     config) in `forwardedProps.configurable` - the AG-UI equivalent of the vanilla
     API's `model` / `user_id` / `agent_config` fields. `thread_id` is taken from
     the AG-UI input by the `ag-ui-langgraph` package itself.
+
+    Applies the same allowlist and thread-ownership checks as the vanilla API's
+    `_handle_input` (see service.py) - both endpoints accept the same kind of
+    caller-supplied `model` / `user_id`, so both need the same guards.
     """
     forwarded: dict[str, Any] = input_data.forwarded_props or {}
     configurable = forwarded.get("configurable") or {}
@@ -50,6 +56,15 @@ def _base_config(input_data: RunAgentInput) -> RunnableConfig:
             status_code=422,
             detail=f"forwardedProps.configurable contains reserved keys: {overlap}",
         )
+
+    if (model := configurable.get("model")) is not None:
+        ensure_model_available(model)
+
+    thread_id = input_data.thread_id or str(uuid4())
+    state = await graph.aget_state(
+        RunnableConfig(configurable={**configurable, "thread_id": thread_id})
+    )
+    ensure_thread_ownership(state.metadata, configurable.get("user_id"))
 
     callbacks: list[Any] = []
     if settings.LANGFUSE_TRACING:
@@ -95,7 +110,7 @@ async def agui_run(
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
 
-    config = _base_config(input_data)
+    config = await _base_config(input_data, graph)
     encoder = EventEncoder(accept=request.headers.get("accept", ""))
     return StreamingResponse(
         _event_stream(agent_id, graph, input_data, config, encoder),

--- a/src/service/agui.py
+++ b/src/service/agui.py
@@ -12,7 +12,6 @@ See docs/AGUI.md for usage, including how to connect a client.
 import logging
 from collections.abc import AsyncGenerator
 from typing import Any
-from uuid import uuid4
 
 from ag_ui.core import EventType, RunAgentInput
 from ag_ui.encoder import EventEncoder
@@ -24,7 +23,7 @@ from langfuse.langchain import CallbackHandler  # type: ignore[import-untyped]
 
 from agents import DEFAULT_AGENT, AgentGraph, get_agent
 from core import settings
-from service.utils import ensure_model_available, ensure_thread_ownership
+from service.utils import ensure_model_available
 
 logger = logging.getLogger(__name__)
 
@@ -35,17 +34,13 @@ router = APIRouter(prefix="/agui")
 RESERVED_CONFIGURABLE_KEYS = {"thread_id", "checkpoint_id", "checkpoint_ns"}
 
 
-async def _base_config(input_data: RunAgentInput, graph: AgentGraph) -> RunnableConfig:
+def _base_config(input_data: RunAgentInput) -> RunnableConfig:
     """Build the base RunnableConfig for an AG-UI run.
 
     Clients can pass configurable values (e.g. `model`, `user_id`, or custom agent
     config) in `forwardedProps.configurable` - the AG-UI equivalent of the vanilla
     API's `model` / `user_id` / `agent_config` fields. `thread_id` is taken from
     the AG-UI input by the `ag-ui-langgraph` package itself.
-
-    Applies the same allowlist and thread-ownership checks as the vanilla API's
-    `_handle_input` (see service.py) - both endpoints accept the same kind of
-    caller-supplied `model` / `user_id`, so both need the same guards.
     """
     forwarded: dict[str, Any] = input_data.forwarded_props or {}
     configurable = forwarded.get("configurable") or {}
@@ -59,12 +54,6 @@ async def _base_config(input_data: RunAgentInput, graph: AgentGraph) -> Runnable
 
     if (model := configurable.get("model")) is not None:
         ensure_model_available(model)
-
-    thread_id = input_data.thread_id or str(uuid4())
-    state = await graph.aget_state(
-        RunnableConfig(configurable={**configurable, "thread_id": thread_id})
-    )
-    ensure_thread_ownership(state.metadata, configurable.get("user_id"))
 
     callbacks: list[Any] = []
     if settings.LANGFUSE_TRACING:
@@ -110,7 +99,7 @@ async def agui_run(
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Agent {agent_id} not found")
 
-    config = await _base_config(input_data, graph)
+    config = _base_config(input_data)
     encoder = EventEncoder(accept=request.headers.get("accept", ""))
     return StreamingResponse(
         _event_stream(agent_id, graph, input_data, config, encoder),

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -38,6 +38,8 @@ from schema import (
 from service.agui import router as agui_router
 from service.utils import (
     convert_message_content_to_string,
+    ensure_model_available,
+    ensure_thread_ownership,
     langchain_to_chat_message,
     remove_tool_calls,
 )
@@ -136,12 +138,7 @@ async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[
 
     configurable = {"thread_id": thread_id, "user_id": user_id}
     if user_input.model is not None:
-        if user_input.model not in settings.AVAILABLE_MODELS:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model '{user_input.model}' is not available. "
-                f"Allowed: {[m.value for m in settings.AVAILABLE_MODELS]}",
-            )
+        ensure_model_available(user_input.model)
         configurable["model"] = user_input.model
 
     callbacks: list[Any] = []
@@ -171,13 +168,7 @@ async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[
     state = await agent.aget_state(config=config)
 
     # Validate that the caller owns this thread
-    if state.values and state.config:
-        stored_user_id = state.config.get("configurable", {}).get("user_id")
-        if stored_user_id and stored_user_id != user_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="thread_id does not belong to the provided user_id",
-            )
+    ensure_thread_ownership(state.metadata, user_id)
 
     interrupted_tasks = [
         task for task in state.tasks if hasattr(task, "interrupts") and task.interrupts
@@ -432,13 +423,7 @@ async def history(input: ChatHistoryInput, agent_id: str = DEFAULT_AGENT) -> Cha
         )
 
         # Validate that the caller owns this thread
-        if input.user_id and state_snapshot.config:
-            stored_user_id = state_snapshot.config.get("configurable", {}).get("user_id")
-            if stored_user_id and stored_user_id != input.user_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="thread_id does not belong to the provided user_id",
-                )
+        ensure_thread_ownership(state_snapshot.metadata, input.user_id)
 
         messages: list[AnyMessage] = state_snapshot.values["messages"]
         chat_messages: list[ChatMessage] = [langchain_to_chat_message(m) for m in messages]

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -39,7 +39,6 @@ from service.agui import router as agui_router
 from service.utils import (
     convert_message_content_to_string,
     ensure_model_available,
-    ensure_thread_ownership,
     langchain_to_chat_message,
     remove_tool_calls,
 )
@@ -166,9 +165,6 @@ async def _handle_input(user_input: UserInput, agent: AgentGraph) -> tuple[dict[
 
     # Check for interrupts that need to be resumed
     state = await agent.aget_state(config=config)
-
-    # Validate that the caller owns this thread
-    ensure_thread_ownership(state.metadata, user_id)
 
     interrupted_tasks = [
         task for task in state.tasks if hasattr(task, "interrupts") and task.interrupts
@@ -421,15 +417,9 @@ async def history(input: ChatHistoryInput, agent_id: str = DEFAULT_AGENT) -> Cha
         state_snapshot = await agent.aget_state(
             config=RunnableConfig(configurable={"thread_id": input.thread_id})
         )
-
-        # Validate that the caller owns this thread
-        ensure_thread_ownership(state_snapshot.metadata, input.user_id)
-
         messages: list[AnyMessage] = state_snapshot.values["messages"]
         chat_messages: list[ChatMessage] = [langchain_to_chat_message(m) for m in messages]
         return ChatHistory(messages=chat_messages)
-    except HTTPException:
-        raise
     except Exception as e:
         logger.error(f"An exception occurred: {e}")
         raise HTTPException(status_code=500, detail="Unexpected error")

--- a/src/service/utils.py
+++ b/src/service/utils.py
@@ -1,5 +1,7 @@
+from collections.abc import Mapping
 from typing import Any, cast
 
+from fastapi import HTTPException, status
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -10,7 +12,41 @@ from langchain_core.messages import (
     ChatMessage as LangchainChatMessage,
 )
 
+from core import settings
 from schema import ChatMessage
+
+
+def ensure_model_available(model: Any) -> None:
+    """Raise 400 if `model` isn't in the operator's AVAILABLE_MODELS allowlist."""
+    if model not in settings.AVAILABLE_MODELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Model '{model}' is not available. "
+            f"Allowed: {[m.value for m in settings.AVAILABLE_MODELS]}",
+        )
+
+
+def ensure_thread_ownership(state_metadata: Mapping[str, Any] | None, user_id: str | None) -> None:
+    """Raise 403 if the thread's stored owner doesn't match the caller-supplied user_id.
+
+    The stored owner lives in checkpoint *metadata*, not `state.config`: LangGraph
+    copies scalar `configurable` values (like `user_id`) into checkpoint metadata at
+    write time (see `get_checkpoint_metadata` in langgraph's checkpoint base), while
+    `state.config` only ever holds the checkpoint-addressing thread_id/checkpoint_ns/
+    checkpoint_id triple - confirmed against both MemorySaver and the Postgres
+    checkpointer. Pass `state.metadata`, not `state.config`.
+
+    No-op if the caller didn't supply a user_id, or the thread has no stored owner
+    (e.g. it predates ownership tracking, or doesn't exist yet).
+    """
+    if not user_id or not state_metadata:
+        return
+    stored_user_id = state_metadata.get("user_id")
+    if stored_user_id and stored_user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="thread_id does not belong to the provided user_id",
+        )
 
 
 def convert_message_content_to_string(content: str | list[str | dict]) -> str:

--- a/src/service/utils.py
+++ b/src/service/utils.py
@@ -1,7 +1,6 @@
-from collections.abc import Mapping
 from typing import Any, cast
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -23,23 +22,6 @@ def ensure_model_available(model: Any) -> None:
             status_code=400,
             detail=f"Model '{model}' is not available. "
             f"Allowed: {[m.value for m in settings.AVAILABLE_MODELS]}",
-        )
-
-
-def ensure_thread_ownership(state_metadata: Mapping[str, Any] | None, user_id: str | None) -> None:
-    """Raise 403 if the thread's stored owner doesn't match the caller-supplied user_id.
-
-    Pass `state.metadata`, not `state.config` - LangGraph copies `configurable`
-    values like `user_id` into checkpoint metadata, not into `state.config` (which
-    only ever holds thread_id/checkpoint_ns/checkpoint_id).
-    """
-    if not user_id or not state_metadata:
-        return
-    stored_user_id = state_metadata.get("user_id")
-    if stored_user_id and stored_user_id != user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="thread_id does not belong to the provided user_id",
         )
 
 

--- a/src/service/utils.py
+++ b/src/service/utils.py
@@ -29,15 +29,9 @@ def ensure_model_available(model: Any) -> None:
 def ensure_thread_ownership(state_metadata: Mapping[str, Any] | None, user_id: str | None) -> None:
     """Raise 403 if the thread's stored owner doesn't match the caller-supplied user_id.
 
-    The stored owner lives in checkpoint *metadata*, not `state.config`: LangGraph
-    copies scalar `configurable` values (like `user_id`) into checkpoint metadata at
-    write time (see `get_checkpoint_metadata` in langgraph's checkpoint base), while
-    `state.config` only ever holds the checkpoint-addressing thread_id/checkpoint_ns/
-    checkpoint_id triple - confirmed against both MemorySaver and the Postgres
-    checkpointer. Pass `state.metadata`, not `state.config`.
-
-    No-op if the caller didn't supply a user_id, or the thread has no stored owner
-    (e.g. it predates ownership tracking, or doesn't exist yet).
+    Pass `state.metadata`, not `state.config` - LangGraph copies `configurable`
+    values like `user_id` into checkpoint metadata, not into `state.config` (which
+    only ever holds thread_id/checkpoint_ns/checkpoint_id).
     """
     if not user_id or not state_metadata:
         return

--- a/tests/service/test_agui.py
+++ b/tests/service/test_agui.py
@@ -181,44 +181,6 @@ def test_agui_configurable_model_not_available(mock_agui_agent, test_client) -> 
     assert "not available" in response.json()["detail"]
 
 
-def test_agui_thread_ownership_rejects_mismatched_user_id(mock_agui_agent, test_client) -> None:
-    """A caller can't read/append to another user's thread by supplying a mismatched user_id."""
-    thread_id = "ownership-thread"
-    # First run establishes the thread under "owner-id".
-    collect_events(
-        test_client,
-        "/agui/model-agent/run",
-        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
-    )
-
-    # A second run claiming a different user_id on the same thread is rejected.
-    response = test_client.post(
-        "/agui/model-agent/run",
-        json=run_input(
-            thread_id, forwardedProps={"configurable": {"user_id": "different-user-id"}}
-        ),
-    )
-    assert response.status_code == 403
-    assert "does not belong" in response.json()["detail"]
-
-
-def test_agui_thread_ownership_allows_matching_user_id(mock_agui_agent, test_client) -> None:
-    """The same user_id can continue their own thread across runs."""
-    thread_id = "ownership-thread-matching"
-    collect_events(
-        test_client,
-        "/agui/model-agent/run",
-        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
-    )
-
-    events = collect_events(
-        test_client,
-        "/agui/model-agent/run",
-        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
-    )
-    assert events[-1]["type"] == "RUN_FINISHED"
-
-
 def test_agui_interrupt_and_resume(mock_agui_agent, test_client) -> None:
     """An interrupt surfaces as an on_interrupt CUSTOM event and can be resumed."""
     thread_id = "interrupt-thread"

--- a/tests/service/test_agui.py
+++ b/tests/service/test_agui.py
@@ -12,6 +12,9 @@ from langgraph.graph import END, MessagesState, StateGraph
 from langgraph.types import interrupt
 from pydantic import TypeAdapter
 
+from core import settings
+from schema.models import FakeModelName
+
 FAKE_RESPONSE = "The answer is 42"
 
 event_adapter: TypeAdapter[Event] = TypeAdapter(Event)
@@ -51,6 +54,12 @@ def _reset_captured_configurable():
     """Every test using model_agent writes to this shared dict; reset before each test."""
     captured_configurable.clear()
     yield
+
+
+@pytest.fixture
+def allow_fake_model(monkeypatch):
+    """Make FakeModelName.FAKE pass the AVAILABLE_MODELS allowlist check."""
+    monkeypatch.setattr(settings, "AVAILABLE_MODELS", {FakeModelName.FAKE})
 
 
 @pytest.fixture
@@ -137,9 +146,12 @@ def test_agui_unknown_agent(mock_agui_agent, test_client) -> None:
     assert response.status_code == 404
 
 
-def test_agui_configurable_passthrough(mock_agui_agent, test_client) -> None:
+def test_agui_configurable_passthrough(mock_agui_agent, allow_fake_model, test_client) -> None:
     """forwardedProps.configurable values reach the agent's configurable."""
-    body = run_input(forwardedProps={"configurable": {"model": "fake", "user_id": "user-123"}})
+    body = run_input(
+        thread_id="passthrough-thread",
+        forwardedProps={"configurable": {"model": "fake", "user_id": "user-123"}},
+    )
     collect_events(test_client, "/agui/model-agent/run", body)
     assert captured_configurable.get("model") == "fake"
     assert captured_configurable.get("user_id") == "user-123"
@@ -156,6 +168,55 @@ def test_agui_configurable_wrong_type(mock_agui_agent, test_client) -> None:
     body = run_input(forwardedProps={"configurable": "not-a-dict"})
     response = test_client.post("/agui/model-agent/run", json=body)
     assert response.status_code == 422
+
+
+def test_agui_configurable_model_not_available(mock_agui_agent, test_client) -> None:
+    """A model outside the operator's AVAILABLE_MODELS allowlist is rejected before the run starts."""
+    body = run_input(
+        thread_id="model-not-available-thread",
+        forwardedProps={"configurable": {"model": "not-a-real-model"}},
+    )
+    response = test_client.post("/agui/model-agent/run", json=body)
+    assert response.status_code == 400
+    assert "not available" in response.json()["detail"]
+
+
+def test_agui_thread_ownership_rejects_mismatched_user_id(mock_agui_agent, test_client) -> None:
+    """A caller can't read/append to another user's thread by supplying a mismatched user_id."""
+    thread_id = "ownership-thread"
+    # First run establishes the thread under "owner-id".
+    collect_events(
+        test_client,
+        "/agui/model-agent/run",
+        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
+    )
+
+    # A second run claiming a different user_id on the same thread is rejected.
+    response = test_client.post(
+        "/agui/model-agent/run",
+        json=run_input(
+            thread_id, forwardedProps={"configurable": {"user_id": "different-user-id"}}
+        ),
+    )
+    assert response.status_code == 403
+    assert "does not belong" in response.json()["detail"]
+
+
+def test_agui_thread_ownership_allows_matching_user_id(mock_agui_agent, test_client) -> None:
+    """The same user_id can continue their own thread across runs."""
+    thread_id = "ownership-thread-matching"
+    collect_events(
+        test_client,
+        "/agui/model-agent/run",
+        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
+    )
+
+    events = collect_events(
+        test_client,
+        "/agui/model-agent/run",
+        run_input(thread_id, forwardedProps={"configurable": {"user_id": "owner-id"}}),
+    )
+    assert events[-1]["type"] == "RUN_FINISHED"
 
 
 def test_agui_interrupt_and_resume(mock_agui_agent, test_client) -> None:

--- a/tests/service/test_service.py
+++ b/tests/service/test_service.py
@@ -222,8 +222,8 @@ def test_history_rejects_mismatched_user_id(test_client, mock_agent) -> None:
     mock_agent.aget_state.return_value = StateSnapshot(
         values={"messages": []},
         next=(),
-        config={"configurable": {"user_id": "owner-id"}},
-        metadata=None,
+        config={},
+        metadata={"user_id": "owner-id"},
         created_at=None,
         parent_config=None,
         tasks=(),
@@ -252,8 +252,8 @@ def test_history_allows_matching_user_id(test_client, mock_agent) -> None:
     mock_agent.aget_state.return_value = StateSnapshot(
         values={"messages": [user_question, agent_response]},
         next=(),
-        config={"configurable": {"user_id": "owner-id"}},
-        metadata=None,
+        config={},
+        metadata={"user_id": "owner-id"},
         created_at=None,
         parent_config=None,
         tasks=(),

--- a/tests/service/test_service.py
+++ b/tests/service/test_service.py
@@ -218,64 +218,6 @@ def test_history(test_client, mock_agent) -> None:
     assert output.messages[1].content == ANSWER
 
 
-def test_history_rejects_mismatched_user_id(test_client, mock_agent) -> None:
-    mock_agent.aget_state.return_value = StateSnapshot(
-        values={"messages": []},
-        next=(),
-        config={},
-        metadata={"user_id": "owner-id"},
-        created_at=None,
-        parent_config=None,
-        tasks=(),
-        interrupts=(),
-    )
-
-    response = test_client.post(
-        "/history",
-        json={
-            "thread_id": "7bcc7cc1-99d7-4b1d-bdb5-e6f90ed44de6",
-            "user_id": "different-user-id",
-        },
-    )
-
-    assert response.status_code == 403
-    assert response.json() == {
-        "detail": "thread_id does not belong to the provided user_id",
-    }
-
-
-def test_history_allows_matching_user_id(test_client, mock_agent) -> None:
-    QUESTION = "What is the weather in Tokyo?"
-    ANSWER = "The weather in Tokyo is 70 degrees."
-    user_question = HumanMessage(content=QUESTION)
-    agent_response = AIMessage(content=ANSWER)
-    mock_agent.aget_state.return_value = StateSnapshot(
-        values={"messages": [user_question, agent_response]},
-        next=(),
-        config={},
-        metadata={"user_id": "owner-id"},
-        created_at=None,
-        parent_config=None,
-        tasks=(),
-        interrupts=(),
-    )
-
-    response = test_client.post(
-        "/history",
-        json={
-            "thread_id": "7bcc7cc1-99d7-4b1d-bdb5-e6f90ed44de6",
-            "user_id": "owner-id",
-        },
-    )
-    assert response.status_code == 200
-
-    output = ChatHistory.model_validate(response.json())
-    assert output.messages[0].type == "human"
-    assert output.messages[0].content == QUESTION
-    assert output.messages[1].type == "ai"
-    assert output.messages[1].content == ANSWER
-
-
 def test_history_custom_agent(test_client) -> None:
     """Test that /{agent_id}/history reads the thread through the requested agent's graph."""
     CUSTOM_AGENT = "custom_agent"

--- a/tests/service/test_utils.py
+++ b/tests/service/test_utils.py
@@ -1,49 +1,6 @@
-import pytest
-from fastapi import HTTPException
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
-from langchain_core.runnables import RunnableConfig
-from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import END, MessagesState, StateGraph
 
-from service.utils import ensure_thread_ownership, langchain_to_chat_message
-
-
-@pytest.mark.asyncio
-async def test_ensure_thread_ownership_against_real_checkpointer() -> None:
-    """Regression test for the #305 bug: the stored user_id must be read from
-    checkpoint metadata, not state.config. A real checkpointer (not a hand-built
-    mock) is required to catch this - #305's own mock-based tests placed user_id
-    under `config`, which a real checkpointer never does, so they passed while the
-    shipped check was dead code. This also pins the LangGraph contract itself, so
-    it fails loudly (here) rather than silently (as a live 403 that never fires) if
-    a future LangGraph version changes where configurable values end up.
-    """
-    graph = StateGraph(MessagesState)
-    graph.add_node("noop", lambda state: {})
-    graph.set_entry_point("noop")
-    graph.add_edge("noop", END)
-    compiled = graph.compile(checkpointer=MemorySaver())
-
-    write_config = RunnableConfig(
-        configurable={"thread_id": "ownership-thread", "user_id": "owner-id"}
-    )
-    await compiled.ainvoke({"messages": []}, config=write_config)
-
-    read_config = RunnableConfig(configurable={"thread_id": "ownership-thread"})
-    state = await compiled.aget_state(read_config)
-
-    # Pin the actual contract ensure_thread_ownership relies on.
-    assert state.config.get("configurable", {}).get("user_id") is None
-    assert state.metadata is not None
-    assert state.metadata.get("user_id") == "owner-id"
-
-    # And exercise the real behavior against that real state.
-    ensure_thread_ownership(state.metadata, "owner-id")  # no raise: matching owner
-    ensure_thread_ownership(state.metadata, None)  # no raise: no user_id supplied
-
-    with pytest.raises(HTTPException) as exc_info:
-        ensure_thread_ownership(state.metadata, "different-user-id")
-    assert exc_info.value.status_code == 403
+from service.utils import langchain_to_chat_message
 
 
 def test_messages_from_langchain() -> None:

--- a/tests/service/test_utils.py
+++ b/tests/service/test_utils.py
@@ -1,6 +1,49 @@
+import pytest
+from fastapi import HTTPException
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolCall, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, MessagesState, StateGraph
 
-from service.utils import langchain_to_chat_message
+from service.utils import ensure_thread_ownership, langchain_to_chat_message
+
+
+@pytest.mark.asyncio
+async def test_ensure_thread_ownership_against_real_checkpointer() -> None:
+    """Regression test for the #305 bug: the stored user_id must be read from
+    checkpoint metadata, not state.config. A real checkpointer (not a hand-built
+    mock) is required to catch this - #305's own mock-based tests placed user_id
+    under `config`, which a real checkpointer never does, so they passed while the
+    shipped check was dead code. This also pins the LangGraph contract itself, so
+    it fails loudly (here) rather than silently (as a live 403 that never fires) if
+    a future LangGraph version changes where configurable values end up.
+    """
+    graph = StateGraph(MessagesState)
+    graph.add_node("noop", lambda state: {})
+    graph.set_entry_point("noop")
+    graph.add_edge("noop", END)
+    compiled = graph.compile(checkpointer=MemorySaver())
+
+    write_config = RunnableConfig(
+        configurable={"thread_id": "ownership-thread", "user_id": "owner-id"}
+    )
+    await compiled.ainvoke({"messages": []}, config=write_config)
+
+    read_config = RunnableConfig(configurable={"thread_id": "ownership-thread"})
+    state = await compiled.aget_state(read_config)
+
+    # Pin the actual contract ensure_thread_ownership relies on.
+    assert state.config.get("configurable", {}).get("user_id") is None
+    assert state.metadata is not None
+    assert state.metadata.get("user_id") == "owner-id"
+
+    # And exercise the real behavior against that real state.
+    ensure_thread_ownership(state.metadata, "owner-id")  # no raise: matching owner
+    ensure_thread_ownership(state.metadata, None)  # no raise: no user_id supplied
+
+    with pytest.raises(HTTPException) as exc_info:
+        ensure_thread_ownership(state.metadata, "different-user-id")
+    assert exc_info.value.status_code == 403
 
 
 def test_messages_from_langchain() -> None:


### PR DESCRIPTION
## Summary

This PR started as "extend #305 and #306's checks to `/agui/run`." It ended up reverting #305 instead. Full history is in the commits, but here's the short version.

### What's kept: AG-UI now enforces the model allowlist (same class as #306)

`forwardedProps.configurable.model` reached the agent with no validation against `settings.AVAILABLE_MODELS` - a caller could force any provider's model regardless of the operator's allowlist, or a model from an unconfigured provider (per-request DoS via a `None` API key reaching the provider client). Extracted `ensure_model_available()` into `service/utils.py` so `_handle_input` and `agui._base_config` share one implementation instead of two copies.

### What's reverted: #305's thread-ownership check

While extending the equivalent ownership check to AG-UI, I found the check #305 shipped never actually worked: it read the stored `user_id` from `state.config`, but LangGraph checkpointers (verified against `MemorySaver` and Postgres) only ever put `thread_id`/`checkpoint_ns`/`checkpoint_id` there. I fixed that (read `state.metadata` instead, where LangGraph actually puts it) and had it working end-to-end with a real-checkpointer regression test.

Then, going through the actual user journey with @JoshuaC215, we concluded the check doesn't hold up as real access control even when "fixed," so it's better removed than shipped fixed but misleading:

- **Bypassed by omission, not just guessing.** The check no-ops if the caller doesn't send `user_id` at all - not a weakness of the fix, the design. Any direct API caller can skip it trivially.
- **Not sticky.** Checkpoint metadata reflects only the current call's `configurable`, not an accumulated record. One legitimate follow-up request that omits `user_id` (dropped query param, different client integration, a raw curl call) silently erases the recorded owner - verified against a real checkpointer. No error, no warning, thread just becomes unowned from then on.
- **Unreachable through the reference client for `/history`.** `AgentClient.get_history()` never had a `user_id` parameter, so the `/history` protection was never exercised by the shipped Streamlit app in the first place.
- **Retrofitted onto a field built for something else.** `UserInput.user_id` predates #305 - it namespaces LangGraph long-term `Store` lookups per-user (see `interrupt_agent.py`'s `determine_birthdate`), not authentication. In the Streamlit app it's a client-generated `uuid4()` that travels in the same shareable URL as `thread_id`, so for the app's actual "share this link" use case it adds ~no protection anyway.

Given `AUTH_SECRET` is a single shared bearer token with no per-user identity, real access control here means per-user auth (e.g. JWTs deriving `user_id` from the credential), not a caller-asserted field. Shipping a check that looks like protection but isn't seemed worse than not having one - hence the revert rather than a "fixed" version.

## Changes

- `service/utils.py`: added `ensure_model_available()`, shared by `_handle_input` and `agui._base_config`. Removed `ensure_thread_ownership()` (was added and removed within this branch).
- `service/agui.py`: `_base_config` now validates `model` before returning the config. No longer touches thread ownership.
- `service/service.py`: `_handle_input` and `history()` use `ensure_model_available()`; the `#305` ownership checks and the now-dead `except HTTPException` re-raise in `history()` are removed.
- `schema/schema.py`: removed `ChatHistoryInput.user_id` (added specifically for the #305 check, no other purpose).
- `docs/AGUI.md`: documents the model allowlist check only.
- Tests: added AG-UI coverage for the model-not-available 400 case; removed all ownership-check tests (mock-based and the real-checkpointer regression test added earlier in this branch).

## Test plan

- [x] `ruff format --check` / `ruff check` clean
- [x] `pyrefly check` clean
- [x] Full test suite passes (120 passed, 3 skipped)
- [x] AG-UI model-not-available case covered against a real compiled graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)