### PR TITLE
fix(deps): unblock Dependabot gitpython security update (alert #157)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ dependencies = [
 [tool.uv]
 exclude-newer = "14 days"
 
+[tool.uv.exclude-newer-package]
+# gitpython 3.1.54 fixes a vulnerability (Dependabot alert #157); streamlit pins it
+# exactly, so the global cooldown blocks resolution until 3.1.54 clears 14 days old.
+# Remove this override once 3.1.54 is >14 days old (~2026-08-05).
+gitpython = "0 days"
+
 [dependency-groups]
 dev = [
     "langgraph-cli[inmem]",

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,9 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
+[options.exclude-newer-package]
+gitpython = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
 [[package]]
 name = "ag-ui-a2ui-toolkit"
 version = "0.0.4"
@@ -1292,14 +1295,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Dependabot's security-update PR for `gitpython` (alert #157,
  [GHSA-rwj8-pgh3-r573](https://github.com/advisories/GHSA-rwj8-pgh3-r573)) failed
  to resolve: `Repo.clone_from()` passes an untrusted URL through `expandvars()`,
  letting a malicious remote leak process environment secrets (e.g.
  `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`) via `$NAME`/`${NAME}` expansion.
  Affects gitpython `<=3.1.51`, patched in `3.1.52`.
- The resolver failed because the target gitpython release fell inside this
  repo's 14-day `exclude-newer` supply-chain cooldown — the cooldown treated it
  as nonexistent and reported the whole dependency set as unsatisfiable for the
  win32/py3.14 split.
- Adds a per-package cooldown override (`[tool.uv.exclude-newer-package]
  gitpython = "0 days"`), the sanctioned exception this repo's
  `dependency-refresh` skill already documents for security fixes, and
  re-locks. The resolver landed on `gitpython==3.1.55` (current release, well
  past the `3.1.52` patched version).

## Test plan

- [x] `uv sync --frozen`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyrefly check`
- [x] `uv run pytest` (143 passed, 3 skipped)

Remove the `gitpython` cooldown override in the next dependency refresh once
`3.1.55` clears the global 14-day cooldown (~2026-08-05).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012xprwFehec8c4CFhLEqsx9

---
_Generated by [Claude Code](https://claude.ai/code/session_012xprwFehec8c4CFhLEqsx9)_