### PR TITLE
Guard template-cleanup against contributor forks

### DIFF
--- a/.github/workflows/template-cleanup.yml
+++ b/.github/workflows/template-cleanup.yml
@@ -14,8 +14,12 @@ permissions:
 
 jobs:
   cleanup:
-    # Only ever run in downstream template copies, never in the source repo.
-    if: github.repository != 'JoshuaC215/agent-service-toolkit'
+    # Run only in genuine template instantiations. The repository check skips the
+    # source repo; the fork check skips contributor forks (also downstream copies,
+    # where a "Use this template" repo has fork == false but a fork has fork == true).
+    if: >-
+      github.repository != 'JoshuaC215/agent-service-toolkit'
+      && github.event.repository.fork == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

The `template-cleanup` workflow added in #348 fired inside a **contributor's fork**, deleted the maintainer scaffolding, and carried those deletions into their PR (see #358: 1834 deletions of `.claude/`, `docs/maintenance/`, `deploy.yml`, `live-smoke-test.yml`, and the cleanup workflow itself, mixed into unrelated feature work).

Root cause: the guard `github.repository != 'JoshuaC215/agent-service-toolkit'` is **true for forks as well as template instances**. A fork is also a downstream copy, so a push to a fork's `main` ran the cleanup there.

## Fix

GitHub distinguishes the two: a repo created via **"Use this template"** has `fork == false`, while a **fork** has `fork == true`. The push payload exposes this as `github.event.repository.fork`, so adding it to the guard runs the cleanup only on genuine template instantiations:

```yaml
if: >-
  github.repository != 'JoshuaC215/agent-service-toolkit'
  && github.event.repository.fork == false
```

- Source repo → `repository ==` → no-op ✓
- Contributor fork → `fork == true` → no-op ✓ (was the bug)
- Template instance → different repo & `fork == false` → runs ✓

## Verification

- YAML parses (`yaml.safe_load`); guard expression confirmed well-formed.

## Note

PR #358's branch already contains the erroneous deletion commits from before this fix; that fork will need to rebase/drop those commits — this change only prevents it from happening to future contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016p3CxQ4oEGQHAhbgtqZwB9)_