### PR TITLE
Refresh LLM model catalog: drop Groq's retiring Llama models

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -203,7 +203,7 @@ class Settings(BaseSettings):
                     self.AVAILABLE_MODELS.update(set(VertexAIModelName))
                 case Provider.GROQ:
                     if self.DEFAULT_MODEL is None:
-                        self.DEFAULT_MODEL = GroqModelName.LLAMA_31_8B
+                        self.DEFAULT_MODEL = GroqModelName.GPT_OSS_20B
                     self.AVAILABLE_MODELS.update(set(GroqModelName))
                 case Provider.AWS:
                     if self.DEFAULT_MODEL is None:

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -77,9 +77,9 @@ class VertexAIModelName(StrEnum):
 class GroqModelName(StrEnum):
     """https://console.groq.com/docs/models"""
 
-    LLAMA_31_8B = "llama-3.1-8b-instant"
-    LLAMA_33_70B = "llama-3.3-70b-versatile"
-
+    # llama-3.1-8b-instant/llama-3.3-70b-versatile retire 2026-08-16 per
+    # https://console.groq.com/docs/deprecations (announced 2026-06-17); dropped
+    # ahead of that date in favor of their recommended gpt-oss replacements below.
     GPT_OSS_20B = "openai/gpt-oss-20b"
     GPT_OSS_120B = "openai/gpt-oss-120b"
     GPT_OSS_SAFEGUARD_20B = "openai/gpt-oss-safeguard-20b"

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -77,9 +77,6 @@ class VertexAIModelName(StrEnum):
 class GroqModelName(StrEnum):
     """https://console.groq.com/docs/models"""
 
-    # llama-3.1-8b-instant/llama-3.3-70b-versatile retire 2026-08-16 per
-    # https://console.groq.com/docs/deprecations (announced 2026-06-17); dropped
-    # ahead of that date in favor of their recommended gpt-oss replacements below.
     GPT_OSS_20B = "openai/gpt-oss-20b"
     GPT_OSS_120B = "openai/gpt-oss-120b"
     GPT_OSS_SAFEGUARD_20B = "openai/gpt-oss-safeguard-20b"

--- a/tests/core/test_llm.py
+++ b/tests/core/test_llm.py
@@ -47,9 +47,9 @@ def test_get_model_anthropic_sonnet_5_omits_temperature():
 
 def test_get_model_groq():
     with patch.dict(os.environ, {"GROQ_API_KEY": "test_key"}):
-        model = get_model(GroqModelName.LLAMA_31_8B)
+        model = get_model(GroqModelName.GPT_OSS_20B)
         assert isinstance(model, ChatGroq)
-        assert model.model_name == "llama-3.1-8b-instant"
+        assert model.model_name == "openai/gpt-oss-20b"
         assert model.temperature == 0.5
 
 


### PR DESCRIPTION
Biweekly model-refresh audit against each provider's current docs, plus a live smoke test (`scripts/check_live_models.py`) against OpenAI, Anthropic, Google, and Groq (Anthropic key passed via `--anthropic-api-key-env LIVE_TEST_CLAUDE_KEY`).

## Changes

**Groq** — remove `llama-3.1-8b-instant` and `llama-3.3-70b-versatile` ahead of their **2026-08-16** retirement (announced 2026-06-17, per [console.groq.com/docs/deprecations](https://console.groq.com/docs/deprecations)). Both still pass the live smoke test today, but the next scheduled biweekly refresh lands *after* the retirement date, so removing now avoids a window where the catalog points at dead models. `DEFAULT_MODEL` for Groq is repointed at `openai/gpt-oss-20b` — Groq's own recommended replacement for `llama-3.1-8b-instant`, and already in the catalog as the fast/cheap tier.

## No changes needed (verified current)

- **OpenAI** — `gpt-5-nano`/`gpt-5-mini`/`gpt-5.1` stay available via the API (retirement 2026-12-10 per `developers.openai.com/api/docs/deprecations`); `gpt-5.6-luna/terra/sol` already cover the latest GA tier. Live: 6/6 PASS.
- **Anthropic** — `claude-haiku-4-5`/`claude-sonnet-4-5`/`claude-sonnet-5` are all **Active** per [platform.claude.com/docs/en/docs/about-claude/models](https://platform.claude.com/docs/en/docs/about-claude/models) and the [deprecations page](https://platform.claude.com/docs/en/docs/about-claude/model-deprecations). Claude Opus 5 and Claude Fable 5 both went GA this cycle but stay out of scope, matching this catalog's established Haiku/Sonnet-only convention (see #337, #351). Live: 3/3 PASS.
- **Google/VertexAI/OpenRouter** — `gemini-2.5-pro`, `3.1-flash-lite`, `3.5-flash`, `3.5-flash-lite`, `3.6-flash`, and `3.1-pro-preview` are all still current per [ai.google.dev/gemini-api/docs/models/gemini](https://ai.google.dev/gemini-api/docs/models/gemini); no newer GA model exists yet. Live: 4/6 PASS (`gemini-2.5-pro` and `gemini-3.1-pro-preview` hit a free-tier 429 quota wall on this key, not a 404 — same pre-existing behavior noted in #351, so the model names are confirmed valid).
- **DeepSeek** — `deepseek-v4-flash`/`deepseek-v4-pro` both current per [api-docs.deepseek.com/quick_start/pricing](https://api-docs.deepseek.com/quick_start/pricing).
- **AWS Bedrock** — doc-only/unverified (no AWS credentials in this environment). `global.anthropic.claude-haiku-4-5-20251001-v1:0` and `global.anthropic.claude-sonnet-5` both confirmed as current Bedrock model/inference-profile IDs via the `docs.aws.amazon.com` model-card pages (fetched through search since WebFetch is blocked on that host). Next person with Bedrock credentials should spot-check via `boto3`.
- **Azure OpenAI** — doc-only/unverified. `azure-gpt-5`/`azure-gpt-5-mini` map to `gpt-5`/`gpt-5-mini`, both still GA on Microsoft Foundry with a 2027-02-06 retirement date — not due for migration. GPT-5.6 is now also sold directly by Azure; deliberately leaving that generation bump out of this routine pass — per the model-refresh skill, Azure enum values double as deployment-map keys, so renaming them is a breaking change for every existing deployment and deserves its own reviewed PR.

## Verification

- `PYTHONPATH=src uv run python scripts/check_live_models.py --anthropic-api-key-env LIVE_TEST_CLAUDE_KEY` — all rows PASS except the two known Google 429s noted above.
- `uv run pytest tests/` — 143 passed, 3 skipped.
- `uv run ruff check src tests scripts` — all checks passed.

Not merging — opening for review per this repo's draft-only workflow.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RaB3eNZju3pAmZ4uy3B1c3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RaB3eNZju3pAmZ4uy3B1c3)_