### PR TITLE
Cover the LangGraph-internals paths in /invoke and /stream (and fix interrupt responses)

### DIFF
--- a/src/service/service.py
+++ b/src/service/service.py
@@ -220,15 +220,16 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
     try:
         response_events: list[tuple[str, Any]] = await agent.ainvoke(**kwargs, stream_mode=["updates", "values"])  # type: ignore # fmt: skip
         response_type, response = response_events[-1]
-        if response_type == "values":
-            # Normal response, the agent completed successfully
-            output = langchain_to_chat_message(response["messages"][-1])
-        elif response_type == "updates" and "__interrupt__" in response:
-            # The last thing to occur was an interrupt
+        # A run that stops on an interrupt reports it on the final event of either stream
+        # mode, so check for the interrupt before falling back to the last message.
+        if "__interrupt__" in response:
             # Return the value of the first interrupt as an AIMessage
             output = langchain_to_chat_message(
                 AIMessage(content=response["__interrupt__"][0].value)
             )
+        elif response_type == "values":
+            # Normal response, the agent completed successfully
+            output = langchain_to_chat_message(response["messages"][-1])
         else:
             raise ValueError(f"Unexpected response type: {response_type}")
 

--- a/tests/service/test_service_real_graphs.py
+++ b/tests/service/test_service_real_graphs.py
@@ -1,0 +1,238 @@
+"""Integration tests for /invoke and /stream against real compiled graphs.
+
+The unit tests in test_service.py drive an AsyncMock agent, so every tuple shape and
+event ordering they assert is hand-built rather than produced by LangGraph. These run the
+same endpoints against real graphs on a real checkpointer, so a change in how LangGraph
+reports interrupts, orders stream events, or surfaces pending tasks shows up here.
+"""
+
+import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.graph import END, MessagesState, StateGraph
+from langgraph.types import StreamWriter, interrupt
+
+from agents.utils import CustomData
+from service import app
+
+
+async def greet(state: MessagesState) -> MessagesState:
+    return {"messages": [AIMessage(content="let me check")]}
+
+
+async def ask_color(state: MessagesState) -> MessagesState:
+    answer = interrupt("What is your favorite color?")
+    return {"messages": [AIMessage(content=f"Your favorite color is {answer}")]}
+
+
+def build_interrupt_agent(checkpointer):
+    """Emits a message before interrupting, so the interrupt arrives mid-stream."""
+    graph = StateGraph(MessagesState)
+    graph.add_node("greet", greet)
+    graph.add_node("ask", ask_color)
+    graph.set_entry_point("greet")
+    graph.add_edge("greet", "ask")
+    graph.add_edge("ask", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+async def count_messages(state: MessagesState) -> MessagesState:
+    return {"messages": [AIMessage(content=f"heard {len(state['messages'])} messages")]}
+
+
+def build_counting_agent(checkpointer):
+    graph = StateGraph(MessagesState)
+    graph.add_node("count", count_messages)
+    graph.set_entry_point("count")
+    graph.add_edge("count", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+async def working(state: MessagesState) -> MessagesState:
+    return {"messages": [AIMessage(content="working on it")]}
+
+
+async def finished(state: MessagesState) -> MessagesState:
+    return {"messages": [AIMessage(content="all done")]}
+
+
+def build_two_step_agent(checkpointer):
+    graph = StateGraph(MessagesState)
+    graph.add_node("working", working)
+    graph.add_node("finished", finished)
+    graph.set_entry_point("working")
+    graph.add_edge("working", "finished")
+    graph.add_edge("finished", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+async def report_progress(state: MessagesState, writer: StreamWriter) -> MessagesState:
+    CustomData(data={"status": "running"}).dispatch(writer)
+    return {"messages": [AIMessage(content="all done")]}
+
+
+def build_custom_data_agent(checkpointer):
+    """The bg-task-agent shape: a node writing custom data alongside its messages."""
+    graph = StateGraph(MessagesState)
+    graph.add_node("report", report_progress)
+    graph.set_entry_point("report")
+    graph.add_edge("report", END)
+    return graph.compile(checkpointer=checkpointer)
+
+
+@pytest_asyncio.fixture(params=["memory", "sqlite"])
+async def checkpointer(request, tmp_path):
+    """Pending interrupts and accumulated messages both round-trip through the
+    checkpointer, so the tests that depend on them run against a real DB as well."""
+    if request.param == "memory":
+        yield MemorySaver()
+    else:
+        async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+            yield saver
+
+
+@asynccontextmanager
+async def client_for(agents: dict[str, Any]) -> AsyncGenerator[httpx.AsyncClient, None]:
+    transport = httpx.ASGITransport(app=app)
+    with patch("service.service.get_agent", side_effect=lambda agent_id: agents[agent_id]):
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+
+
+async def stream_events(client: httpx.AsyncClient, path: str, body: dict) -> list[dict[str, Any]]:
+    events = []
+    async with client.stream("POST", path, json=body) as response:
+        assert response.status_code == 200
+        async for line in response.aiter_lines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            events.append(json.loads(line.removeprefix("data: ")))
+    return events
+
+
+def streamed_messages(events: list[dict[str, Any]]) -> list[tuple[str, Any]]:
+    return [
+        (e["content"]["type"], e["content"]["content"]) for e in events if e["type"] == "message"
+    ]
+
+
+async def history_of(client: httpx.AsyncClient, path: str, thread_id: str) -> list[tuple[str, str]]:
+    response = await client.post(path, json={"thread_id": thread_id})
+    assert response.status_code == 200
+    return [(m["type"], m["content"]) for m in response.json()["messages"]]
+
+
+@pytest.mark.asyncio
+async def test_invoke_resumes_an_interrupted_thread(checkpointer) -> None:
+    """The second call must resume the pending interrupt, not start a fresh turn."""
+    agents = {"interrupt-graph": build_interrupt_agent(checkpointer)}
+    async with client_for(agents) as client:
+        first = await client.post(
+            "/interrupt-graph/invoke", json={"message": "hi", "thread_id": "t"}
+        )
+        assert first.status_code == 200
+        assert (first.json()["type"], first.json()["content"]) == (
+            "ai",
+            "What is your favorite color?",
+        )
+
+        second = await client.post(
+            "/interrupt-graph/invoke", json={"message": "blue", "thread_id": "t"}
+        )
+        assert second.status_code == 200
+        assert (second.json()["type"], second.json()["content"]) == (
+            "ai",
+            "Your favorite color is blue",
+        )
+
+        assert await history_of(client, "/interrupt-graph/history", "t") == [
+            ("human", "hi"),
+            ("ai", "let me check"),
+            ("ai", "Your favorite color is blue"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_stream_resumes_an_interrupted_thread(checkpointer) -> None:
+    agents = {"interrupt-graph": build_interrupt_agent(checkpointer)}
+    async with client_for(agents) as client:
+        first = await stream_events(
+            client, "/interrupt-graph/stream", {"message": "hi", "thread_id": "t"}
+        )
+        assert streamed_messages(first) == [
+            ("ai", "let me check"),
+            ("ai", "What is your favorite color?"),
+        ]
+
+        second = await stream_events(
+            client, "/interrupt-graph/stream", {"message": "blue", "thread_id": "t"}
+        )
+        assert streamed_messages(second) == [("ai", "Your favorite color is blue")]
+
+        assert await history_of(client, "/interrupt-graph/history", "t") == [
+            ("human", "hi"),
+            ("ai", "let me check"),
+            ("ai", "Your favorite color is blue"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_invoke_accumulates_state_across_turns(checkpointer) -> None:
+    agents = {"counting-agent": build_counting_agent(checkpointer)}
+    async with client_for(agents) as client:
+        contents = []
+        for message in ["first", "second"]:
+            response = await client.post(
+                "/counting-agent/invoke", json={"message": message, "thread_id": "t"}
+            )
+            assert response.status_code == 200
+            contents.append(response.json()["content"])
+
+        assert contents == ["heard 1 messages", "heard 3 messages"]
+        assert await history_of(client, "/counting-agent/history", "t") == [
+            ("human", "first"),
+            ("ai", "heard 1 messages"),
+            ("human", "second"),
+            ("ai", "heard 3 messages"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_invoke_returns_only_the_final_message() -> None:
+    """Pins the documented limitation: intermediate AIMessages are dropped by /invoke."""
+    agents = {"two-step-agent": build_two_step_agent(MemorySaver())}
+    async with client_for(agents) as client:
+        response = await client.post(
+            "/two-step-agent/invoke", json={"message": "hi", "thread_id": "t"}
+        )
+        assert response.status_code == 200
+        assert (response.json()["type"], response.json()["content"]) == ("ai", "all done")
+
+        assert await history_of(client, "/two-step-agent/history", "t") == [
+            ("human", "hi"),
+            ("ai", "working on it"),
+            ("ai", "all done"),
+        ]
+
+
+@pytest.mark.asyncio
+async def test_stream_forwards_custom_data() -> None:
+    agents = {"custom-agent": build_custom_data_agent(MemorySaver())}
+    async with client_for(agents) as client:
+        events = await stream_events(
+            client, "/custom-agent/stream", {"message": "hi", "thread_id": "t"}
+        )
+
+        messages = [e["content"] for e in events if e["type"] == "message"]
+        assert [m["type"] for m in messages] == ["custom", "ai"]
+        assert messages[0]["custom_data"] == {"status": "running"}
+        assert messages[1]["content"] == "all done"


### PR DESCRIPTION
Follow-up to #366. That PR added the first tests running real graphs through a real checkpointer; this one answers the question it raised — **which other parts of the service depend on LangGraph internals that no test would catch drifting?**

Adds `tests/service/test_service_real_graphs.py`: `/invoke` and `/stream` driven against real compiled graphs on real checkpointers, rather than the `AsyncMock` agent the existing service tests use.

## Found a real bug: `/invoke` is broken for interrupting agents

This isn't just a coverage gap — the code it covers was dead.

Against a real graph, `ainvoke(stream_mode=["updates", "values"])` on an interrupting run emits **three** events, and the last one is a `values` event that carries the interrupt:

```
('values',  {'messages': [Human 'hi']})
('updates', {'__interrupt__': (Interrupt(value='What is your favorite color?'),)})
('values',  {'messages': [Human 'hi'], '__interrupt__': (Interrupt(...),)})
```

`invoke()` checked `response_type == "values"` **first**, so it never reached the `elif response_type == "updates" and "__interrupt__" in response` branch. Confirmed end-to-end through the API — `/invoke` returned the user's own echoed message instead of the interrupt prompt:

```
turn1 200 {'type': 'human', 'content': 'hi', ...}
```

The existing `test_invoke_interrupt` passes because its mock hand-builds a two-element list ending in `updates` — an ordering LangGraph doesn't produce.

**Fix applied** (`src/service/service.py`, reorder only): check `"__interrupt__" in response` before the `values` fallback. Both branches already assumed a dict, and every agent state in the repo is `MessagesState`-derived, so nothing else changes. `test_invoke_interrupt` still passes unchanged. `/stream` was never affected — it reads `__interrupt__` off the `updates` node key, which still arrives.

This is the only behaviour change in the PR; everything else is test-only.

## Coverage added

8 tests, **0.19s total**, slowest 0.03s.

| test | covers | checkpointer |
|---|---|---|
| `test_invoke_resumes_an_interrupted_thread` | `_handle_input` resume branch | memory + sqlite |
| `test_stream_resumes_an_interrupted_thread` | resume branch, mid-stream `__interrupt__` | memory + sqlite |
| `test_invoke_accumulates_state_across_turns` | multi-turn state continuity | memory + sqlite |
| `test_invoke_returns_only_the_final_message` | pins the documented "last message only" limitation | memory |
| `test_stream_forwards_custom_data` | `stream_mode="custom"` (bg-task-agent path) | memory |

The resume tests' real discriminator is the `/history` assertion: after resuming, history must read `[human "hi", ai "let me check", ai "Your favorite color is blue"]` — no second `human` turn. If `_handle_input` sent a `HumanMessage` instead of `Command(resume=...)`, the graph would restart and re-interrupt.

The interrupt graph is two nodes (`greet` → `ask`) so the `__interrupt__` update genuinely arrives mid-stream after a prior message, covering that case from the same fixture. Only the tests whose behaviour round-trips through the checkpointer pay the sqlite parametrization; the two pure stream-shape tests use `MemorySaver` directly.

All graphs are built inline — no imports from `src/agents/` beyond the `CustomData` helper, which is what the custom-data test is about.

## Every test shown to fail

Eight mutations of `src/service/service.py`, restoring after each:

| mutation | tests that failed |
|---|---|
| `interrupted_tasks = []` | both resume tests (4 runs) |
| `Command(resume="")` | both resume tests (4 runs) |
| revert interrupt check to updates-only | `invoke_resumes` (2) |
| `response["messages"][0]` | `invoke_resumes`, `accumulates`, `only_the_final_message` (5) |
| drop `__interrupt__` from `updates` | `stream_resumes` (2) |
| drop `stream_mode == "custom"` | `stream_forwards_custom_data` |
| ignore `user_input.thread_id` | 7 of 8 |
| remove `subgraphs=True` | **none** — see below |

Every test in the file fails under at least one mutation of the code it claims to cover.

## Left out, deliberately

**The `('content', ...)` / `('tool_calls', [...])` part-tuple accumulation has no test, because local LangGraph never emits that shape.** I probed `updates`, `messages`, and `custom` across single-node, multi-node, interrupting, and custom-writer graphs: `updates` always carries real `BaseMessage` objects. That code path is for `RemoteGraph` / LangGraph Platform, which is what the linked how-to in the comment documents. A test would have meant hand-feeding tuples into the generator — asserting the fixture, not LangGraph.

The surviving `subgraphs=True` mutation is the honest counterpart: none of these graphs have subgraphs, and `test_service_message_generator.py` already covers that tuple arity via the supervisor hierarchy.

`./scripts/smoke_test.sh` was not run. Nothing in the checkpointer/persistence layer changed — the diff is a branch reorder in `invoke()` response parsing — and neither the smoke test nor `test_service_e2e.py` touches interrupts.

## Verification

```
uv run pytest tests/ -q                → 178 passed, 4 skipped   (baseline 170 + 8)
uv run ruff format . && ruff check .   → All checks passed
uv run pyrefly check                   → 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRcfekayLs7QZcPvWjqDXW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRcfekayLs7QZcPvWjqDXW)_