### PR TITLE
fix(vertexai): prefix the two colliding Gemini slugs and enforce value uniqueness

### DIFF
--- a/.claude/skills/model-refresh/SKILL.md
+++ b/.claude/skills/model-refresh/SKILL.md
@@ -69,14 +69,10 @@ per-provider `DEFAULT_MODEL` fallbacks point at a model that still exists.
    - Enum values are the exact string the provider's API expects
      (`claude-sonnet-4-5`, `gemini-2.5-pro`, `gpt-5.1`) — copy verbatim from the
      provider docs, don't guess.
-   - Values must be unique across *all* the enums in `AllModelEnum`, which
-     `tests/schema/test_models.py` enforces. `StrEnum` hashes by value, so a
-     shared value collapses two members into one and `get_model` silently routes
-     both to whichever branch is checked first. This bites where two providers
-     serve the same upstream model: `VertexAIModelName` therefore uses the
-     `models/`-prefixed form (Vertex resolves it to the same resource path) to
-     stay distinct from `GoogleModelName`. Keep that prefix on new Vertex
-     entries, and expect the same for any future router-style provider.
+   - Values must be unique across *all* the enums in `AllModelEnum` —
+     `tests/schema/test_models.py` enforces this. Where two providers serve the
+     same upstream model one side needs a distinguishing form: `VertexAIModelName`
+     uses the `models/` prefix, so keep it on new Vertex entries.
    - Keep provider families grouped and roughly ordered by size/generation within
      a class, matching how they read today.
 4. **Apply changes across every coupled location** — do not edit only the enum:

--- a/.claude/skills/model-refresh/SKILL.md
+++ b/.claude/skills/model-refresh/SKILL.md
@@ -69,6 +69,14 @@ per-provider `DEFAULT_MODEL` fallbacks point at a model that still exists.
    - Enum values are the exact string the provider's API expects
      (`claude-sonnet-4-5`, `gemini-2.5-pro`, `gpt-5.1`) — copy verbatim from the
      provider docs, don't guess.
+   - Values must be unique across *all* the enums in `AllModelEnum`, which
+     `tests/schema/test_models.py` enforces. `StrEnum` hashes by value, so a
+     shared value collapses two members into one and `get_model` silently routes
+     both to whichever branch is checked first. This bites where two providers
+     serve the same upstream model: `VertexAIModelName` therefore uses the
+     `models/`-prefixed form (Vertex resolves it to the same resource path) to
+     stay distinct from `GoogleModelName`. Keep that prefix on new Vertex
+     entries, and expect the same for any future router-style provider.
    - Keep provider families grouped and roughly ordered by size/generation within
      a class, matching how they read today.
 4. **Apply changes across every coupled location** — do not edit only the enum:

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -65,10 +65,8 @@ class GoogleModelName(StrEnum):
 class VertexAIModelName(StrEnum):
     """https://cloud.google.com/vertex-ai/generative-ai/docs/models"""
 
-    # The models/ prefix is required to keep these distinct from GoogleModelName:
-    # StrEnum hashes by value, so a shared value collapses the two members into one
-    # and get_model routes the Gemini API branch first. Vertex resolves both the
-    # bare and models/-prefixed forms to the same resource path.
+    # The models/ prefix keeps every value distinct from its GoogleModelName twin;
+    # Vertex resolves it to the same resource path as the bare name.
     GEMINI_25_PRO = "models/gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "models/gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "models/gemini-3.5-flash"

--- a/src/schema/models.py
+++ b/src/schema/models.py
@@ -65,13 +65,17 @@ class GoogleModelName(StrEnum):
 class VertexAIModelName(StrEnum):
     """https://cloud.google.com/vertex-ai/generative-ai/docs/models"""
 
-    GEMINI_25_PRO = "gemini-2.5-pro"
+    # The models/ prefix is required to keep these distinct from GoogleModelName:
+    # StrEnum hashes by value, so a shared value collapses the two members into one
+    # and get_model routes the Gemini API branch first. Vertex resolves both the
+    # bare and models/-prefixed forms to the same resource path.
+    GEMINI_25_PRO = "models/gemini-2.5-pro"
     GEMINI_31_FLASH_LITE = "models/gemini-3.1-flash-lite"
     GEMINI_35_FLASH = "models/gemini-3.5-flash"
     GEMINI_35_FLASH_LITE = "models/gemini-3.5-flash-lite"
     GEMINI_36_FLASH = "models/gemini-3.6-flash"
     # gemini-3-pro-preview was shut down 2026-03-09; 3.1 is the current preview-tier pro model.
-    GEMINI_31_PRO_PREVIEW = "gemini-3.1-pro-preview"
+    GEMINI_31_PRO_PREVIEW = "models/gemini-3.1-pro-preview"
 
 
 class GroqModelName(StrEnum):

--- a/tests/schema/test_models.py
+++ b/tests/schema/test_models.py
@@ -1,0 +1,46 @@
+"""Invariants for the model catalog that get_model's dispatch depends on."""
+
+import typing
+from collections import defaultdict
+
+import pytest
+
+from core.llm import _MODEL_TABLE
+from schema.models import AllModelEnum, GoogleModelName, VertexAIModelName
+
+MODEL_ENUMS = typing.get_args(AllModelEnum.__value__)
+
+
+def test_model_enums_are_all_discovered():
+    # Guards the introspection the other tests rely on: a silently empty tuple
+    # would make them pass without checking anything.
+    assert len(MODEL_ENUMS) >= 12
+
+
+def test_model_values_are_unique_across_enums():
+    # StrEnum hashes by value, not by name, so two members sharing a value collapse
+    # into one entry in llm._MODEL_TABLE and in settings.AVAILABLE_MODELS. get_model
+    # then routes both to whichever branch is checked first, silently sending
+    # requests to the wrong provider with the wrong credentials.
+    owners = defaultdict(list)
+    for enum in MODEL_ENUMS:
+        for member in enum:
+            owners[member.value].append(f"{enum.__name__}.{member.name}")
+
+    duplicates = {value: names for value, names in owners.items() if len(names) > 1}
+    assert not duplicates, f"model values must be unique across enums: {duplicates}"
+
+
+@pytest.mark.parametrize("model", list(VertexAIModelName), ids=lambda m: m.value)
+def test_vertexai_models_do_not_collide_with_google(model):
+    # A Vertex-only operator selecting a colliding value used to pass the
+    # AVAILABLE_MODELS allowlist and then get built as ChatGoogleGenerativeAI,
+    # failing with "API key required for Gemini Developer API".
+    assert model not in GoogleModelName
+
+
+def test_model_table_covers_every_model():
+    # _MODEL_TABLE is maintained separately from the AllModelEnum union; an enum
+    # added to one but not the other makes get_model raise "Unsupported model"
+    # for a catalog entry the picker still offers.
+    assert set(_MODEL_TABLE) == {member for enum in MODEL_ENUMS for member in enum}

--- a/tests/schema/test_models.py
+++ b/tests/schema/test_models.py
@@ -12,16 +12,13 @@ MODEL_ENUMS = typing.get_args(AllModelEnum.__value__)
 
 
 def test_model_enums_are_all_discovered():
-    # Guards the introspection the other tests rely on: a silently empty tuple
-    # would make them pass without checking anything.
+    # An empty tuple would make the tests below pass without checking anything.
     assert len(MODEL_ENUMS) >= 12
 
 
 def test_model_values_are_unique_across_enums():
-    # StrEnum hashes by value, not by name, so two members sharing a value collapse
-    # into one entry in llm._MODEL_TABLE and in settings.AVAILABLE_MODELS. get_model
-    # then routes both to whichever branch is checked first, silently sending
-    # requests to the wrong provider with the wrong credentials.
+    # StrEnum hashes by value, so members sharing a value collapse into one entry in
+    # _MODEL_TABLE and AVAILABLE_MODELS, and get_model routes both to the first branch.
     owners = defaultdict(list)
     for enum in MODEL_ENUMS:
         for member in enum:
@@ -33,14 +30,10 @@ def test_model_values_are_unique_across_enums():
 
 @pytest.mark.parametrize("model", list(VertexAIModelName), ids=lambda m: m.value)
 def test_vertexai_models_do_not_collide_with_google(model):
-    # A Vertex-only operator selecting a colliding value used to pass the
-    # AVAILABLE_MODELS allowlist and then get built as ChatGoogleGenerativeAI,
-    # failing with "API key required for Gemini Developer API".
+    # Every Vertex model has a Google twin, so a collision here builds the wrong client.
     assert model not in GoogleModelName
 
 
 def test_model_table_covers_every_model():
-    # _MODEL_TABLE is maintained separately from the AllModelEnum union; an enum
-    # added to one but not the other makes get_model raise "Unsupported model"
-    # for a catalog entry the picker still offers.
+    # _MODEL_TABLE is maintained separately from the AllModelEnum union.
     assert set(_MODEL_TABLE) == {member for enum in MODEL_ENUMS for member in enum}


### PR DESCRIPTION
Follow-up to #371. The uniqueness test I deferred there turned out to be guarding a live bug, not just a latent one.

## The collision was breaking Vertex

`VertexAIModelName.GEMINI_25_PRO` and `GEMINI_31_PRO_PREVIEW` carried the same values as their `GoogleModelName` counterparts. `StrEnum` hashes by value, not by name, so each pair collapsed into a single entry in `llm._MODEL_TABLE` and in `settings.AVAILABLE_MODELS` — and `get_model` checks `GoogleModelName` first.

A Vertex-only operator (`GOOGLE_APPLICATION_CREDENTIALS` set, no `GOOGLE_API_KEY`) selecting `gemini-2.5-pro` on `main`:

```
DEFAULT_MODEL parsed as : <GoogleModelName.GEMINI_25_PRO: 'gemini-2.5-pro'>
in AVAILABLE_MODELS?    : True
get_model               -> ChatGoogleGenerativeAI
ValidationError: API key required for Gemini Developer API.
```

It passes the allowlist (the Google member compares equal to the Vertex one), then gets built against the wrong provider. Those two models were simply unreachable on Vertex.

## Fix

Prefix both with `models/`, completing a convention that was already in place: **all six Vertex models have a `GoogleModelName` twin**, and #351 added the `models/`-prefixed form for the Vertex side of each new pair. The prefix just never got backfilled onto these two older entries — which is exactly why they were the broken ones.

`models/` is also the only prefix that works without a code change. `langchain_google_vertexai._utils._format_model_name` special-cases it, so both forms resolve to the same resource path:

```
gemini-2.5-pro            -> projects/{p}/locations/{l}/publishers/google/models/gemini-2.5-pro
models/gemini-2.5-pro     -> projects/{p}/locations/{l}/publishers/google/models/gemini-2.5-pro
vertex/gemini-2.5-pro     -> vertex/gemini-2.5-pro   # passed through unchanged
```

`GoogleModelName` keeps the bare values, so the Gemini API path is untouched — verified `GOOGLE_API_KEY` + `DEFAULT_MODEL=gemini-2.5-pro` still builds `ChatGoogleGenerativeAI`.

## Breaking-change note

Per the model-refresh skill's "flag any model rename explicitly": the two `VertexAIModelName` **values** change, so a config pinning `gemini-2.5-pro`/`gemini-3.1-pro-preview` for Vertex needs the `models/` prefix. No *working* configuration breaks, though — as shown above, those values never reached Vertex in the first place. Google API users are unaffected.

## Tests

`tests/schema/test_models.py` (new, 9 cases):

- **`test_model_values_are_unique_across_enums`** — the invariant, written generically over `typing.get_args(AllModelEnum.__value__)`, so it automatically covers any enum added to the union later. This is the check that would have caught an OrcaRouter/OpenRouter slug clash in #365.
- **`test_vertexai_models_do_not_collide_with_google`** — parametrized regression guard for the routing bug above.
- **`test_model_table_covers_every_model`** — `_MODEL_TABLE` in `core/llm.py` is maintained separately from the union in `schema/models.py`; an enum added to one but not the other makes `get_model` raise `Unsupported model` for a catalog entry the picker still offers.
- **`test_model_enums_are_all_discovered`** — guards the introspection itself, so a silently empty tuple can't make the others vacuously pass.

Also added a note to `.claude/skills/model-refresh/SKILL.md` so a future catalog refresh doesn't reintroduce a bare Vertex slug — its current guidance ("enum values are the exact string the provider's API expects, copy verbatim") points the other way.

## Verification

- Full suite: **190 passed, 4 skipped** (181 on `main`; +9 new, no errors)
- `ruff check` / `ruff format --check` clean; `pyrefly check` → 0 errors
- Mutation-checked: reverting the `GEMINI_25_PRO` slug fails both the uniqueness test and the parametrized collision test; dropping an enum from `_MODEL_TABLE` fails the coverage test
- End-to-end: `models/gemini-2.5-pro` now parses as `VertexAIModelName` and dispatches to the Vertex branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKx8pL5t27ZAhw45w7rj2V