### PR TITLE
fix: keep SSE agent streams alive during quiet periods

### DIFF
--- a/src/client/client.py
+++ b/src/client/client.py
@@ -1,6 +1,7 @@
 import json
 import os
 from collections.abc import AsyncGenerator, Generator
+from enum import Enum
 from typing import Any
 
 import httpx
@@ -20,6 +21,11 @@ from schema import (
 
 class AgentClientError(Exception):
     pass
+
+
+class _StreamControl(Enum):
+    IGNORE = "ignore"
+    DONE = "done"
 
 
 class AgentClient:
@@ -176,30 +182,34 @@ class AgentClient:
 
         return ChatMessage.model_validate(response.json())
 
-    def _parse_stream_line(self, line: str) -> ChatMessage | str | None:
+    def _parse_stream_line(self, line: str) -> ChatMessage | str | _StreamControl:
         line = line.strip()
-        if line.startswith("data: "):
-            data = line[6:]
-            if data == "[DONE]":
-                return None
-            try:
-                parsed = json.loads(data)
-            except Exception as e:
-                raise Exception(f"Error JSON parsing message from server: {e}")
-            match parsed["type"]:
-                case "message":
-                    # Convert the JSON formatted message to an AnyMessage
-                    try:
-                        return ChatMessage.model_validate(parsed["content"])
-                    except Exception as e:
-                        raise Exception(f"Server returned invalid message: {e}")
-                case "token":
-                    # Yield the str token directly
-                    return parsed["content"]
-                case "error":
-                    error_msg = "Error: " + parsed["content"]
-                    return ChatMessage(type="ai", content=error_msg)
-        return None
+        if not line or line.startswith(":") or not line.startswith("data:"):
+            return _StreamControl.IGNORE
+
+        data = line[5:].lstrip()
+        if data == "[DONE]":
+            return _StreamControl.DONE
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as e:
+            raise AgentClientError(f"Error JSON parsing message from server: {e}") from e
+        if not isinstance(parsed, dict):
+            return _StreamControl.IGNORE
+
+        match parsed.get("type"):
+            case "message":
+                try:
+                    return ChatMessage.model_validate(parsed["content"])
+                except (KeyError, TypeError, ValueError) as e:
+                    raise AgentClientError(f"Server returned invalid message: {e}") from e
+            case "token":
+                return parsed["content"]
+            case "error":
+                error_msg = "Error: " + parsed["content"]
+                return ChatMessage(type="ai", content=error_msg)
+            case _:
+                return _StreamControl.IGNORE
 
     def stream(
         self,
@@ -252,8 +262,10 @@ class AgentClient:
                 for line in response.iter_lines():
                     if line.strip():
                         parsed = self._parse_stream_line(line)
-                        if parsed is None:
+                        if parsed is _StreamControl.DONE:
                             break
+                        if parsed is _StreamControl.IGNORE:
+                            continue
                         yield parsed
         except httpx.HTTPError as e:
             raise AgentClientError(f"Error: {e}")
@@ -310,8 +322,10 @@ class AgentClient:
                     async for line in response.aiter_lines():
                         if line.strip():
                             parsed = self._parse_stream_line(line)
-                            if parsed is None:
+                            if parsed is _StreamControl.DONE:
                                 break
+                            if parsed is _StreamControl.IGNORE:
+                                continue
                             # Don't yield empty string tokens as they cause generator issues
                             if parsed != "":
                                 yield parsed

--- a/src/service/service.py
+++ b/src/service/service.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import json
 import logging
@@ -240,6 +241,52 @@ async def invoke(user_input: UserInput, agent_id: str = DEFAULT_AGENT) -> ChatMe
         raise HTTPException(status_code=500, detail="Unexpected error")
 
 
+_SSE_PING = ": ping\n\n"
+_KEEP_ALIVE_INTERVAL = 15.0
+_STREAM_QUEUE_MAXSIZE = 1
+
+
+async def _agent_stream_with_keepalive(
+    agent: AgentGraph,
+    kwargs: dict[str, Any],
+    interval: float = _KEEP_ALIVE_INTERVAL,
+    queue_size: int = _STREAM_QUEUE_MAXSIZE,
+) -> AsyncGenerator[Any | str, None]:
+    """Yield agent events while keeping quiet SSE connections alive."""
+    if interval <= 0:
+        raise ValueError("interval must be greater than zero")
+    if queue_size <= 0:
+        raise ValueError("queue_size must be greater than zero")
+
+    queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=queue_size)
+
+    async def produce() -> None:
+        async for event in agent.astream(  # type: ignore[no-matching-overload]
+            **kwargs, stream_mode=["updates", "messages", "custom"], subgraphs=True
+        ):
+            await queue.put(event)
+
+    producer_task = asyncio.create_task(produce())
+    try:
+        while True:
+            if producer_task.done() and queue.empty():
+                producer_task.result()
+                break
+            try:
+                event = await asyncio.wait_for(queue.get(), timeout=interval)
+            except TimeoutError:
+                if producer_task.done() and queue.empty():
+                    producer_task.result()
+                    break
+                yield _SSE_PING
+            else:
+                yield event
+    finally:
+        if not producer_task.done():
+            producer_task.cancel()
+        await asyncio.gather(producer_task, return_exceptions=True)
+
+
 async def message_generator(
     user_input: StreamInput, agent_id: str = DEFAULT_AGENT
 ) -> AsyncGenerator[str, None]:
@@ -253,9 +300,10 @@ async def message_generator(
 
     try:
         # Process streamed events from the graph and yield messages over the SSE stream.
-        async for stream_event in agent.astream(  # type: ignore[no-matching-overload]
-            **kwargs, stream_mode=["updates", "messages", "custom"], subgraphs=True
-        ):
+        async for stream_event in _agent_stream_with_keepalive(agent, kwargs):
+            if stream_event == _SSE_PING:
+                yield _SSE_PING
+                continue
             if not isinstance(stream_event, tuple):
                 continue
             # Handle different stream event structures based on subgraphs

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -130,6 +130,7 @@ def test_stream(agent_client):
     # Create mock response with streaming events
     events = (
         [f"data: {json.dumps({'type': 'token', 'content': token})}" for token in TOKENS]
+        + [": ping"]
         + [
             f"data: {json.dumps({'type': 'message', 'content': {'type': 'ai', 'content': FINAL_ANSWER}})}"
         ]
@@ -182,6 +183,7 @@ async def test_astream(agent_client):
     # Create mock response with streaming events
     events = (
         [f"data: {json.dumps({'type': 'token', 'content': token})}" for token in TOKENS]
+        + [": ping"]
         + [
             f"data: {json.dumps({'type': 'message', 'content': {'type': 'ai', 'content': FINAL_ANSWER}})}"
         ]

--- a/tests/service/test_service_keepalive.py
+++ b/tests/service/test_service_keepalive.py
@@ -1,0 +1,63 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from service.service import _SSE_PING, _agent_stream_with_keepalive
+
+
+@pytest.mark.asyncio
+async def test_keepalive_emits_ping_during_silent_agent() -> None:
+    event = ("messages", ("answer", {"tags": []}))
+
+    async def astream(**kwargs):
+        await asyncio.sleep(0.02)
+        yield event
+
+    agent = SimpleNamespace(astream=astream)
+    stream = _agent_stream_with_keepalive(agent, {}, interval=0.005)
+
+    assert await anext(stream) == _SSE_PING
+    for _ in range(10):
+        next_event = await asyncio.wait_for(anext(stream), timeout=1)
+        if next_event == event:
+            break
+    else:
+        pytest.fail("agent event was not yielded")
+    with pytest.raises(StopAsyncIteration):
+        await anext(stream)
+
+
+@pytest.mark.asyncio
+async def test_keepalive_cancels_agent_when_client_disconnects() -> None:
+    cancelled = asyncio.Event()
+
+    async def astream(**kwargs):
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+        if False:
+            yield None
+
+    agent = SimpleNamespace(astream=astream)
+    stream = _agent_stream_with_keepalive(agent, {}, interval=0.005)
+
+    assert await anext(stream) == _SSE_PING
+    await stream.aclose()
+
+    assert cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_keepalive_propagates_agent_errors() -> None:
+    async def astream(**kwargs):
+        raise RuntimeError("agent failed")
+        if False:
+            yield None
+
+    agent = SimpleNamespace(astream=astream)
+    stream = _agent_stream_with_keepalive(agent, {}, interval=0.005)
+
+    with pytest.raises(RuntimeError, match="agent failed"):
+        await anext(stream)


### PR DESCRIPTION
## Summary
- keep SSE agent streams alive during quiet periods
- bound the event queue and propagate producer failures
- clean up producers when clients disconnect
- accept SSE heartbeat comments in sync and async clients
- add regression tests

## Testing
- pytest tests/service tests/client
- full non-UI test suite

Fixes #126
